### PR TITLE
Adiciona endpoint e botão para geração manual de DocumentUnits por Re…

### DIFF
--- a/client/rufino_v2/lib/data/repositories/require_document_repository_impl.dart
+++ b/client/rufino_v2/lib/data/repositories/require_document_repository_impl.dart
@@ -205,6 +205,20 @@ class RequireDocumentRepositoryImpl implements RequireDocumentRepository {
     }
   }
 
+  @override
+  Future<Result<String>> generateDocumentUnits(
+      String companyId, String requireDocumentId) async {
+    try {
+      final id = await apiService.generateDocumentUnits(
+          companyId, requireDocumentId);
+      return Result.success(id);
+    } on RequireDocumentException catch (e) {
+      return Result.error(e);
+    } catch (e) {
+      return Result.error(RequireDocumentNetworkException(e));
+    }
+  }
+
   /// Translates status names from English API keys to Brazilian Portuguese.
   static String _translateStatusName(String name) {
     const map = {

--- a/client/rufino_v2/lib/data/services/require_document_api_service.dart
+++ b/client/rufino_v2/lib/data/services/require_document_api_service.dart
@@ -162,4 +162,15 @@ class RequireDocumentApiService {
     return list.cast<Map<String, dynamic>>();
   }
 
+  /// Triggers generation of document units for all employees matching
+  /// the require document identified by [requireDocumentId].
+  Future<String> generateDocumentUnits(
+      String companyId, String requireDocumentId) async {
+    final uri = Uri.https(
+        baseUrl, '/api/v1/$companyId/requiredocuments/$requireDocumentId/generate');
+    final response = await client.post(uri, headers: await _headers());
+    checkHttpStatus(response);
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return json['id'] as String;
+  }
 }

--- a/client/rufino_v2/lib/domain/repositories/require_document_repository.dart
+++ b/client/rufino_v2/lib/domain/repositories/require_document_repository.dart
@@ -49,6 +49,11 @@ abstract class RequireDocumentRepository {
 
   /// Returns the available document templates (simplified) for the given [companyId].
   Future<Result<List<SelectionOption>>> getDocumentTemplates(String companyId);
+
+  /// Triggers generation of document units for all employees matching
+  /// the require document identified by [requireDocumentId].
+  Future<Result<String>> generateDocumentUnits(
+      String companyId, String requireDocumentId);
 }
 
 /// Payload for a listen event when creating or updating a require document.

--- a/client/rufino_v2/lib/ui/features/require_document/viewmodel/require_document_form_viewmodel.dart
+++ b/client/rufino_v2/lib/ui/features/require_document/viewmodel/require_document_form_viewmodel.dart
@@ -9,7 +9,7 @@ import '../../../../domain/repositories/company_repository.dart';
 import '../../../../domain/repositories/require_document_repository.dart';
 
 /// Possible statuses for the require document form screen.
-enum RequireDocumentFormStatus { loading, idle, saving, saved, error }
+enum RequireDocumentFormStatus { loading, idle, saving, saved, generating, generated, error }
 
 /// Manages state for creating or editing a require document.
 ///
@@ -74,6 +74,9 @@ class RequireDocumentFormViewModel extends ChangeNotifier {
 
   /// Whether the form is currently submitting data to the API.
   bool get isSaving => _status == RequireDocumentFormStatus.saving;
+
+  /// Whether document generation is currently in progress.
+  bool get isGenerating => _status == RequireDocumentFormStatus.generating;
 
   /// Whether this ViewModel is in create mode (no existing require document).
   bool get isNew => _id.isEmpty;
@@ -425,6 +428,38 @@ class RequireDocumentFormViewModel extends ChangeNotifier {
           _errorMessage = _serverErrors.isNotEmpty
               ? _serverErrors.join('\n')
               : 'Falha ao salvar requerimento. Verifique os dados e tente novamente.';
+        },
+      );
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  /// Triggers generation of document units for all employees matching
+  /// this require document's associations.
+  Future<void> generateDocumentUnits() async {
+    if (_id.isEmpty) return;
+
+    _status = RequireDocumentFormStatus.generating;
+    _errorMessage = null;
+    _serverErrors = const [];
+    notifyListeners();
+
+    try {
+      final companyResult = await _companyRepository.getSelectedCompany();
+      final companyId = companyResult.valueOrNull?.id ?? '';
+
+      final result = await _requireDocumentRepository.generateDocumentUnits(
+          companyId, _id);
+
+      result.fold(
+        onSuccess: (_) => _status = RequireDocumentFormStatus.generated,
+        onError: (error) {
+          _status = RequireDocumentFormStatus.error;
+          _serverErrors = extractServerMessages(error);
+          _errorMessage = _serverErrors.isNotEmpty
+              ? _serverErrors.join('\n')
+              : 'Falha ao gerar documentos. Tente novamente.';
         },
       );
     } finally {

--- a/client/rufino_v2/lib/ui/features/require_document/widgets/require_document_form_screen.dart
+++ b/client/rufino_v2/lib/ui/features/require_document/widgets/require_document_form_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/theme/app_spacing.dart';
 import '../../../core/widgets/error_dialog.dart';
+import '../../../core/widgets/permission_guard.dart';
 import '../viewmodel/require_document_form_viewmodel.dart';
 
 /// Form screen for creating or editing a require document.
@@ -73,6 +74,13 @@ class _RequireDocumentFormScreenState extends State<RequireDocumentFormScreen> {
           ),
         );
         context.pop();
+      case RequireDocumentFormStatus.generated:
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Geração de documentos iniciada com sucesso!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
       case RequireDocumentFormStatus.error:
         showErrorSnackBar(
           context,
@@ -246,6 +254,15 @@ class _RequireDocumentFormBody extends StatelessWidget {
 
               // ─── Listen Events ───────────────────────────────────────
               _ListenEventsSection(viewModel: viewModel),
+              const SizedBox(height: AppSpacing.lg),
+
+              // ─── Generate Documents ─────────────────────────────────
+              if (!viewModel.isNew)
+                PermissionGuard(
+                  resource: 'require-documents',
+                  scope: 'generate',
+                  child: _GenerateDocumentsSection(viewModel: viewModel),
+                ),
               const SizedBox(height: AppSpacing.xl),
 
               // ─── Actions ─────────────────────────────────────────────
@@ -551,6 +568,87 @@ class _ListenEventCard extends StatelessWidget {
     );
   }
 
+}
+
+/// Section with a button to generate document units for all matching employees.
+class _GenerateDocumentsSection extends StatelessWidget {
+  const _GenerateDocumentsSection({required this.viewModel});
+
+  final RequireDocumentFormViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return InputDecorator(
+      decoration: InputDecoration(
+        labelText: 'Geração de Documentos',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(4)),
+        contentPadding:
+            const EdgeInsets.fromLTRB(12, AppSpacing.md, 12, AppSpacing.sm),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(top: AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Gera os documentos para todos os funcionários que '
+              'correspondem às associações deste requerimento.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: viewModel.isGenerating
+                  ? const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : OutlinedButton.icon(
+                      onPressed: () =>
+                          _showGenerateConfirmation(context, viewModel),
+                      icon: const Icon(Icons.play_arrow, size: 18),
+                      label: const Text('Gerar Documentos'),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showGenerateConfirmation(
+      BuildContext context, RequireDocumentFormViewModel viewModel) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Confirmar Geração'),
+        content: const Text(
+          'Esta ação irá gerar documentos para todos os funcionários '
+          'que correspondem às associações deste requerimento. '
+          'Deseja continuar?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Confirmar'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      viewModel.generateDocumentUnits();
+    }
+  }
 }
 
 /// Save and cancel action buttons for the form.

--- a/client/rufino_v2/test/testing/fakes/fake_require_document_repository.dart
+++ b/client/rufino_v2/test/testing/fakes/fake_require_document_repository.dart
@@ -30,6 +30,9 @@ class FakeRequireDocumentRepository implements RequireDocumentRepository {
   /// The last association type id passed to [getAssociations].
   String? lastAssociationTypeId;
 
+  /// The id passed to the last [generateDocumentUnits] call.
+  String? lastGeneratedRequireDocumentId;
+
   @override
   Future<Result<List<RequireDocument>>> getRequireDocuments(
       String companyId) async {
@@ -144,5 +147,15 @@ class FakeRequireDocumentRepository implements RequireDocumentRepository {
       SelectionOption(id: 'tpl-1', name: 'Contrato CLT'),
       SelectionOption(id: 'tpl-2', name: 'Termo de Confidencialidade'),
     ]);
+  }
+
+  @override
+  Future<Result<String>> generateDocumentUnits(
+      String companyId, String requireDocumentId) async {
+    if (_shouldFail) {
+      return Result.error(Exception('generateDocumentUnits failed'));
+    }
+    lastGeneratedRequireDocumentId = requireDocumentId;
+    return Result.success(requireDocumentId);
   }
 }

--- a/client/rufino_v2/test/unit/ui/features/require_document/require_document_form_viewmodel_test.dart
+++ b/client/rufino_v2/test/unit/ui/features/require_document/require_document_form_viewmodel_test.dart
@@ -229,5 +229,33 @@ void main() {
 
       expect(viewModel.listenEvents.first.statuses, isEmpty);
     });
+
+    test('generateDocumentUnits transitions to generated on success',
+        () async {
+      await viewModel.loadRequireDocument('req-1');
+
+      await viewModel.generateDocumentUnits();
+
+      expect(viewModel.status, RequireDocumentFormStatus.generated);
+      expect(requireDocumentRepository.lastGeneratedRequireDocumentId,
+          'req-1');
+    });
+
+    test('generateDocumentUnits transitions to error when repository fails',
+        () async {
+      await viewModel.loadRequireDocument('req-1');
+      requireDocumentRepository.setShouldFail(true);
+
+      await viewModel.generateDocumentUnits();
+
+      expect(viewModel.status, RequireDocumentFormStatus.error);
+    });
+
+    test('generateDocumentUnits does nothing when id is empty', () async {
+      await viewModel.generateDocumentUnits();
+
+      expect(viewModel.status, RequireDocumentFormStatus.idle);
+      expect(requireDocumentRepository.lastGeneratedRequireDocumentId, isNull);
+    });
   });
 }

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/RequireDocumentsController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/RequireDocumentsController.cs
@@ -2,6 +2,7 @@
 using PeopleManagement.Application.Commands.Identified;
 using PeopleManagement.Application.Commands.RequireDocumentsCommands.CreateRequireSecurityDocuments;
 using PeopleManagement.Application.Commands.RequireDocumentsCommands.EditRequireSecurityDocuments;
+using PeopleManagement.Application.Commands.RequireDocumentsCommands.GenerateDocumentUnits;
 using PeopleManagement.Application.Queries.RequireDocuments;
 using PeopleManagement.Domain.AggregatesModel.EmployeeAggregate.Events;
 using PeopleManagement.Domain.AggregatesModel.RequireDocumentsAggregate;
@@ -93,6 +94,22 @@ namespace PeopleManagement.API.Controllers
         public ActionResult<RecurringEvents[]> GetEvents([FromRoute] Guid company)
         {
             var result = RecurringEvents.GetAll().ToArray();
+            return OkResponse(result);
+        }
+
+        [HttpPost("{id}/generate")]
+        [ProtectedResource("require-documents", "generate")]
+        public async Task<ActionResult<GenerateDocumentUnitsResponse>> Generate([FromRoute] Guid company, [FromRoute] Guid id, [FromHeader(Name = "x-requestid")] Guid requestId)
+        {
+            var model = new GenerateDocumentUnitsModel(id);
+            var command = new IdentifiedCommand<GenerateDocumentUnitsCommand, GenerateDocumentUnitsResponse>(model.ToCommand(company), requestId);
+
+            SendingCommandLog(id, model, requestId);
+
+            var result = await _mediator.Send(command);
+
+            CommandResultLog(result, id, model, requestId);
+
             return OkResponse(result);
         }
 

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsCommand.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsCommand.cs
@@ -1,0 +1,9 @@
+namespace PeopleManagement.Application.Commands.RequireDocumentsCommands.GenerateDocumentUnits
+{
+    public record GenerateDocumentUnitsCommand(Guid RequireDocumentId, Guid CompanyId) : IRequest<GenerateDocumentUnitsResponse>;
+
+    public record GenerateDocumentUnitsModel(Guid RequireDocumentId)
+    {
+        public GenerateDocumentUnitsCommand ToCommand(Guid company) => new(RequireDocumentId, company);
+    }
+}

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsCommandHandler.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsCommandHandler.cs
@@ -1,0 +1,38 @@
+using PeopleManagement.Application.Commands.Identified;
+using PeopleManagement.Domain.AggregatesModel.DocumentAggregate.Interfaces;
+using PeopleManagement.Domain.AggregatesModel.RequireDocumentsAggregate;
+using PeopleManagement.Domain.AggregatesModel.RequireDocumentsAggregate.Interfaces;
+using PeopleManagement.Domain.ErrorTools;
+using PeopleManagement.Domain.ErrorTools.ErrorsMessages;
+using PeopleManagement.Infra.Idempotency;
+
+namespace PeopleManagement.Application.Commands.RequireDocumentsCommands.GenerateDocumentUnits
+{
+    public sealed class GenerateDocumentUnitsCommandHandler(
+        IRequireDocumentsRepository requireDocumentsRepository,
+        IDocumentService documentService) : IRequestHandler<GenerateDocumentUnitsCommand, GenerateDocumentUnitsResponse>
+    {
+        private readonly IRequireDocumentsRepository _requireDocumentsRepository = requireDocumentsRepository;
+        private readonly IDocumentService _documentService = documentService;
+
+        public async Task<GenerateDocumentUnitsResponse> Handle(GenerateDocumentUnitsCommand request, CancellationToken cancellationToken)
+        {
+            var requireDocument = await _requireDocumentsRepository.FirstOrDefaultAsync(
+                x => x.Id == request.RequireDocumentId && x.CompanyId == request.CompanyId, cancellation: cancellationToken)
+                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(RequireDocuments), request.RequireDocumentId.ToString()));
+
+            await _documentService.GenerateDocumentUnitsForRequireDocument(request.RequireDocumentId, request.CompanyId, cancellationToken);
+
+            return requireDocument.Id;
+        }
+
+        public class GenerateDocumentUnitsIdentifiedCommandHandler(
+            IMediator mediator,
+            ILogger<IdentifiedCommandHandler<GenerateDocumentUnitsCommand, GenerateDocumentUnitsResponse>> logger,
+            IRequestManager requestManager)
+            : IdentifiedCommandHandler<GenerateDocumentUnitsCommand, GenerateDocumentUnitsResponse>(mediator, logger, requestManager)
+        {
+            protected override GenerateDocumentUnitsResponse CreateResultForDuplicateRequest() => new(Guid.Empty);
+        }
+    }
+}

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsResponse.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/RequireDocumentsCommands/GenerateDocumentUnits/GenerateDocumentUnitsResponse.cs
@@ -1,0 +1,7 @@
+namespace PeopleManagement.Application.Commands.RequireDocumentsCommands.GenerateDocumentUnits
+{
+    public record GenerateDocumentUnitsResponse(Guid Id) : BaseDTO(Id)
+    {
+        public static implicit operator GenerateDocumentUnitsResponse(Guid id) => new(id);
+    }
+}

--- a/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/Interfaces/IDocumentService.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/Interfaces/IDocumentService.cs
@@ -10,5 +10,6 @@
             IEnumerable<(Guid DocumentId, IEnumerable<Guid> DocumentUnitIds)> items,
             Guid employeeId, Guid companyId, CancellationToken cancellationToken = default);
         Task InsertFileWithoutRequireValidation(Guid documentUnitId, Guid documentId, Guid employeeId, Guid companyId, Extension extension, Stream stream, CancellationToken cancellationToken = default);
+        Task GenerateDocumentUnitsForRequireDocument(Guid requireDocumentId, Guid companyId, CancellationToken cancellationToken = default);
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Services/Services/DocumentService.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Services/Services/DocumentService.cs
@@ -19,6 +19,7 @@ using PeopleManagement.Domain.ErrorTools.ErrorsMessages;
 using PeopleManagement.Domain.Options;
 using PeopleManagement.Domain.Utils;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text.Json.Nodes;
 using System.Threading;
 using Document = PeopleManagement.Domain.AggregatesModel.DocumentAggregate.Document;
@@ -154,6 +155,99 @@ namespace PeopleManagement.Services.Services
                     documentsToInsert.Count, employeeId, eventId);
             }
 
+        }
+
+        public async Task GenerateDocumentUnitsForRequireDocument(Guid requireDocumentId, Guid companyId, CancellationToken cancellationToken = default)
+        {
+            var requireDocument = await _requireDocumentsRepository.FirstOrDefaultAsync(
+                x => x.Id == requireDocumentId && x.CompanyId == companyId, cancellation: cancellationToken)
+                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(RequireDocuments), requireDocumentId.ToString()));
+
+            if (!requireDocument.DocumentsTemplatesIds.Any())
+            {
+                _logger.LogInformation("RequireDocument {RequireDocumentId} has no document templates. Skipping.", requireDocumentId);
+                return;
+            }
+
+            Expression<Func<Employee, bool>> employeeFilter = requireDocument.AssociationType.Id == AssociationType.Role.Id
+                ? e => e.CompanyId == companyId && requireDocument.AssociationIds.Contains(e.RoleId)
+                : e => e.CompanyId == companyId && requireDocument.AssociationIds.Contains(e.WorkPlaceId);
+
+            var employees = await _employeeRepository.GetDataAsync(employeeFilter, cancellation: cancellationToken);
+
+            if (!employees.Any())
+            {
+                _logger.LogInformation("No employees found matching associations for RequireDocument {RequireDocumentId}.", requireDocumentId);
+                return;
+            }
+
+            _logger.LogInformation("Generating document units for RequireDocument {RequireDocumentId} across {EmployeeCount} employees.",
+                requireDocumentId, employees.Count());
+
+            await Parallel.ForEachAsync(employees, cancellationToken, async (employee, ct) =>
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var scopedDocumentRepository = scope.ServiceProvider.GetRequiredService<IDocumentRepository>();
+                var scopedDocumentTemplateRepository = scope.ServiceProvider.GetRequiredService<IDocumentTemplateRepository>();
+
+                var existingDocuments = await scopedDocumentRepository.GetDataAsync(
+                    x => requireDocument.DocumentsTemplatesIds.Contains(x.DocumentTemplateId) && x.EmployeeId == employee.Id,
+                    cancellation: ct);
+
+                var existingDocumentsByTemplateId = existingDocuments.ToDictionary(d => d.DocumentTemplateId);
+
+                var templateIdsWithoutDocuments = requireDocument.DocumentsTemplatesIds
+                    .Except(existingDocumentsByTemplateId.Keys)
+                    .ToList();
+
+                var documentTemplates = templateIdsWithoutDocuments.Any()
+                    ? await scopedDocumentTemplateRepository.GetDataAsync(
+                        x => templateIdsWithoutDocuments.Contains(x.Id) && x.CompanyId == companyId,
+                        cancellation: ct)
+                    : [];
+
+                var documentTemplatesByTemplateId = documentTemplates.ToDictionary(dt => dt.Id);
+
+                var documentsToInsert = new List<Document>();
+
+                foreach (var templateId in requireDocument.DocumentsTemplatesIds)
+                {
+                    if (!existingDocumentsByTemplateId.TryGetValue(templateId, out var document))
+                    {
+                        if (!documentTemplatesByTemplateId.TryGetValue(templateId, out var documentTemplate))
+                        {
+                            _logger.LogWarning("Document template {TemplateId} not found for company {CompanyId}. Skipping.", templateId, companyId);
+                            continue;
+                        }
+
+                        var documentId = Guid.NewGuid();
+                        document = Document.Create(
+                            documentId,
+                            employee.Id,
+                            companyId,
+                            requireDocument.Id,
+                            templateId,
+                            documentTemplate.Name.Value,
+                            documentTemplate.Description.Value,
+                            documentTemplate.UsePreviousPeriod);
+
+                        documentsToInsert.Add(document);
+                        existingDocumentsByTemplateId[templateId] = document;
+                    }
+
+                    var documentUnitId = Guid.NewGuid();
+                    document.NewDocumentUnit(documentUnitId);
+                }
+
+                if (documentsToInsert.Any())
+                {
+                    await scopedDocumentRepository.InsertRangeAsync(documentsToInsert, ct);
+                }
+
+                await scopedDocumentRepository.UnitOfWork.SaveChangesAsync(ct);
+            });
+
+            _logger.LogInformation("Completed generating document units for RequireDocument {RequireDocumentId}.", requireDocumentId);
         }
 
         private (PeriodType? periodType, DateTime? referenceDate) GetPeriodInfoFromEvent(int eventId)


### PR DESCRIPTION
…quireDocument

  Cria endpoint POST /requiredocuments/{id}/generate com permissão própria
  (require-documents:generate) que gera DocumentUnits para todos os
  funcionários que correspondem às associações do requerimento selecionado.
  No frontend, adiciona botão "Gerar Documentos" na tela de edição do
  requerimento com diálogo de confirmação e PermissionGuard.