### PR TITLE
Corrige atualização do EmployeeDocumentStatus na criação de documentos

### DIFF
--- a/server/Services/PeopleManagement/PeopleManagement.Infra/ExtensionClass/MediatorExtension.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Infra/ExtensionClass/MediatorExtension.cs
@@ -9,24 +9,27 @@ namespace PeopleManagement.Infra.ExtensionClass
     {
         public static async Task DispatchDomainEventsAsync(this IMediator mediator, PeopleManagementContext ctx)
         {
-            var domainEntities = ctx.ChangeTracker
-                .Entries<Entity>()
-                .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Count != 0);
-
-            var domainEvents = domainEntities
-                .SelectMany(x => x.Entity.DomainEvents)
-                .ToList();
-
-            domainEntities.ToList()
-                .ForEach(entity => entity.Entity.ClearDomainEvents());
-
-
-
-            foreach (var domainEvent in domainEvents)
+            while (true)
             {
-                await mediator.Publish(domainEvent);
+                var domainEntities = ctx.ChangeTracker
+                    .Entries<Entity>()
+                    .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Count != 0)
+                    .ToList();
+
+                if (domainEntities.Count == 0)
+                    break;
+
+                var domainEvents = domainEntities
+                    .SelectMany(x => x.Entity.DomainEvents)
+                    .ToList();
+
+                domainEntities.ForEach(entity => entity.Entity.ClearDomainEvents());
+
+                foreach (var domainEvent in domainEvents)
+                {
+                    await mediator.Publish(domainEvent);
+                }
             }
-                
         }
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Infra/Repository/DocumentRepository.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Infra/Repository/DocumentRepository.cs
@@ -9,11 +9,21 @@ namespace PeopleManagement.Infra.Repository
     {
         public async Task<List<DocumentStatus>> GetAllStatusByEmployeeAsync(Guid employeeId, Guid companyId, CancellationToken cancellationToken = default)
         {
-            return await context.Documents
+            var dbStatuses = await context.Documents
                 .Where(x => x.EmployeeId == employeeId && x.CompanyId == companyId)
                 .OrderByDescending(x => x.CreatedAt)
                 .Select(x => x.Status)
                 .ToListAsync(cancellationToken);
+
+            var addedStatuses = context.ChangeTracker.Entries<Document>()
+                .Where(e => e.State == EntityState.Added
+                    && e.Entity.EmployeeId == employeeId
+                    && e.Entity.CompanyId == companyId)
+                .Select(e => e.Entity.Status)
+                .ToList();
+
+            dbStatuses.AddRange(addedStatuses);
+            return dbStatuses;
         }
     }
 }


### PR DESCRIPTION
  Eventos de domínio criados durante o dispatch eram perdidos porque
  DispatchDomainEventsAsync iterava apenas uma vez. Agora itera em loop
  até não haver mais eventos pendentes. Além disso, GetAllStatusByEmployee
  agora inclui documentos no estado Added do change tracker, garantindo que
  o cálculo do status considere documentos recém-criados antes do save.