### PR TITLE
 Separa validações de data por entidade e alinha contrato ao backend

### DIFF
--- a/client/rufino_v2/lib/domain/entities/employee_contract.dart
+++ b/client/rufino_v2/lib/domain/entities/employee_contract.dart
@@ -29,10 +29,11 @@ class EmployeeContractInfo {
 
   // ─── Validators ──────────────────────────────────────────────────────────
 
-  /// Validates a contract date in `dd/MM/yyyy` format.
+  /// Validates a contract init date in `dd/MM/yyyy` format.
   ///
-  /// Must be a valid date within ±365 days of today.
-  static String? validateDate(String? value) {
+  /// Must be a valid date between 12 years in the past and 1 year in the
+  /// future, matching backend `EmploymentContract.InitDate` rules.
+  static String? validateInitDate(String? value) {
     final stripped = (value ?? '').replaceAll(RegExp(r'[^\d]'), '');
     if (stripped.isEmpty) {
       return 'A data não pode ser vazia.';
@@ -47,14 +48,47 @@ class EmployeeContractInfo {
       if (date == null) return 'Data inválida.';
 
       final now = DateTime.now();
-      final minDate = now.subtract(const Duration(days: 365));
-      final maxDate = now.add(const Duration(days: 365));
+      final minDate = DateTime(now.year - 12, now.month, now.day);
+      final maxDate = DateTime(now.year + 1, now.month, now.day);
       if (date.isBefore(minDate) || date.isAfter(maxDate)) {
-        return 'Data inválida.';
+        return 'A data deve estar entre ${_formatDate(minDate)} e ${_formatDate(maxDate)}.';
       }
     } catch (_) {
       return 'Data inválida.';
     }
     return null;
   }
+
+  /// Validates a contract final date in `dd/MM/yyyy` format.
+  ///
+  /// Must be a valid date within ±1 year of today, matching backend
+  /// `EmploymentContract.FinalDate` rules.
+  static String? validateFinalDate(String? value) {
+    final stripped = (value ?? '').replaceAll(RegExp(r'[^\d]'), '');
+    if (stripped.isEmpty) {
+      return 'A data não pode ser vazia.';
+    }
+    if (stripped.length != 8) {
+      return 'Data inválida (ex: 15/03/2026).';
+    }
+    try {
+      final parts = value!.split('/');
+      final date =
+          DateTime.tryParse('${parts[2]}-${parts[1]}-${parts[0]}');
+      if (date == null) return 'Data inválida.';
+
+      final now = DateTime.now();
+      final minDate = DateTime(now.year - 1, now.month, now.day);
+      final maxDate = DateTime(now.year + 1, now.month, now.day);
+      if (date.isBefore(minDate) || date.isAfter(maxDate)) {
+        return 'A data deve estar entre ${_formatDate(minDate)} e ${_formatDate(maxDate)}.';
+      }
+    } catch (_) {
+      return 'Data inválida.';
+    }
+    return null;
+  }
+
+  static String _formatDate(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
 }

--- a/client/rufino_v2/lib/domain/entities/employee_document.dart
+++ b/client/rufino_v2/lib/domain/entities/employee_document.dart
@@ -142,6 +142,31 @@ class DocumentUnit {
         '${date.substring(0, 2)}';
   }
 
+  // ─── Validators ──────────────────────────────────────────────────────────
+
+  /// Validates a document unit date in `dd/MM/yyyy` format.
+  ///
+  /// Only checks format — no range restriction. The backend validates
+  /// `Date != MinValue && Date != MaxValue` at domain level.
+  static String? validateDate(String? value) {
+    final stripped = (value ?? '').replaceAll(RegExp(r'[^\d]'), '');
+    if (stripped.isEmpty) {
+      return 'A data não pode ser vazia.';
+    }
+    if (stripped.length != 8) {
+      return 'Data inválida (ex: 15/03/2026).';
+    }
+    try {
+      final parts = value!.split('/');
+      final date =
+          DateTime.tryParse('${parts[2]}-${parts[1]}-${parts[0]}');
+      if (date == null) return 'Data inválida.';
+    } catch (_) {
+      return 'Data inválida.';
+    }
+    return null;
+  }
+
   /// Builds a download file name from this unit's date and the parent
   /// [docName], e.g. `"2026-03-01-contrato-de-trabalho.pdf"`.
   String downloadFileName(String docName, {String extension = 'pdf'}) {

--- a/client/rufino_v2/lib/ui/features/employee/viewmodel/employee_profile_viewmodel.dart
+++ b/client/rufino_v2/lib/ui/features/employee/viewmodel/employee_profile_viewmodel.dart
@@ -2140,9 +2140,19 @@ class EmployeeProfileViewModel extends ChangeNotifier {
 
   // ── Contract validators ──────────────────────────────────────────────────
 
-  /// Delegates to [EmployeeContractInfo.validateDate].
-  String? validateContractDate(String? value) =>
-      EmployeeContractInfo.validateDate(value);
+  /// Delegates to [EmployeeContractInfo.validateInitDate].
+  String? validateContractInitDate(String? value) =>
+      EmployeeContractInfo.validateInitDate(value);
+
+  /// Delegates to [EmployeeContractInfo.validateFinalDate].
+  String? validateContractFinalDate(String? value) =>
+      EmployeeContractInfo.validateFinalDate(value);
+
+  // ── Document unit validators ────────────────────────────────────────────
+
+  /// Delegates to [DocumentUnit.validateDate].
+  String? validateDocumentUnitDate(String? value) =>
+      DocumentUnit.validateDate(value);
 
   // ── Dependent validators ─────────────────────────────────────────────────
 

--- a/client/rufino_v2/lib/ui/features/employee/widgets/components/contract_section.dart
+++ b/client/rufino_v2/lib/ui/features/employee/widgets/components/contract_section.dart
@@ -236,7 +236,7 @@ class _ContractSectionState extends State<ContractSection> {
             ),
             keyboardType: TextInputType.number,
             inputFormatters: [dateMask],
-            validator: widget.viewModel.validateContractDate,
+            validator: widget.viewModel.validateContractFinalDate,
           ),
         ),
         actions: [
@@ -305,7 +305,7 @@ class _ContractSectionState extends State<ContractSection> {
                     ),
                     keyboardType: TextInputType.number,
                     inputFormatters: [dateMask],
-                    validator: widget.viewModel.validateContractDate,
+                    validator: widget.viewModel.validateContractInitDate,
                   ),
                   const SizedBox(height: AppSpacing.md),
                   DropdownButtonFormField<String>(

--- a/client/rufino_v2/lib/ui/features/employee/widgets/components/documents_section.dart
+++ b/client/rufino_v2/lib/ui/features/employee/widgets/components/documents_section.dart
@@ -166,7 +166,7 @@ class _DocumentsSectionState extends State<DocumentsSection> {
               ),
               keyboardType: TextInputType.number,
               inputFormatters: [dateMask],
-              validator: widget.viewModel.validateContractDate,
+              validator: widget.viewModel.validateDocumentUnitDate,
             ),
           ),
           actions: [
@@ -791,7 +791,7 @@ class _DocumentsSectionState extends State<DocumentsSection> {
                   ),
                   keyboardType: TextInputType.number,
                   inputFormatters: [dateMask],
-                  validator: widget.viewModel.validateContractDate,
+                  validator: widget.viewModel.validateDocumentUnitDate,
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 Row(

--- a/client/rufino_v2/test/unit/domain/entities/employee_contract_test.dart
+++ b/client/rufino_v2/test/unit/domain/entities/employee_contract_test.dart
@@ -26,22 +26,22 @@ void main() {
     });
   });
 
-  group('EmployeeContractInfo.validateDate', () {
+  group('EmployeeContractInfo.validateInitDate', () {
     test('returns error when empty', () {
-      expect(EmployeeContractInfo.validateDate(null), isNotNull);
-      expect(EmployeeContractInfo.validateDate(''), isNotNull);
+      expect(EmployeeContractInfo.validateInitDate(null), isNotNull);
+      expect(EmployeeContractInfo.validateInitDate(''), isNotNull);
     });
 
     test('returns error for wrong digit count', () {
-      expect(EmployeeContractInfo.validateDate('01/01'), isNotNull);
+      expect(EmployeeContractInfo.validateInitDate('01/01'), isNotNull);
     });
 
-    test('returns error for date more than 365 days in the past', () {
-      expect(EmployeeContractInfo.validateDate('01/01/2020'), isNotNull);
+    test('returns error for date more than 12 years in the past', () {
+      expect(EmployeeContractInfo.validateInitDate('01/01/2010'), isNotNull);
     });
 
-    test('returns error for date more than 365 days in the future', () {
-      expect(EmployeeContractInfo.validateDate('01/01/2099'), isNotNull);
+    test('returns error for date more than 1 year in the future', () {
+      expect(EmployeeContractInfo.validateInitDate('01/01/2099'), isNotNull);
     });
 
     test('returns null for today', () {
@@ -49,7 +49,36 @@ void main() {
       final day = now.day.toString().padLeft(2, '0');
       final month = now.month.toString().padLeft(2, '0');
       final year = now.year.toString();
-      expect(EmployeeContractInfo.validateDate('$day/$month/$year'), isNull);
+      expect(
+          EmployeeContractInfo.validateInitDate('$day/$month/$year'), isNull);
+    });
+  });
+
+  group('EmployeeContractInfo.validateFinalDate', () {
+    test('returns error when empty', () {
+      expect(EmployeeContractInfo.validateFinalDate(null), isNotNull);
+      expect(EmployeeContractInfo.validateFinalDate(''), isNotNull);
+    });
+
+    test('returns error for wrong digit count', () {
+      expect(EmployeeContractInfo.validateFinalDate('01/01'), isNotNull);
+    });
+
+    test('returns error for date more than 1 year in the past', () {
+      expect(EmployeeContractInfo.validateFinalDate('01/01/2020'), isNotNull);
+    });
+
+    test('returns error for date more than 1 year in the future', () {
+      expect(EmployeeContractInfo.validateFinalDate('01/01/2099'), isNotNull);
+    });
+
+    test('returns null for today', () {
+      final now = DateTime.now();
+      final day = now.day.toString().padLeft(2, '0');
+      final month = now.month.toString().padLeft(2, '0');
+      final year = now.year.toString();
+      expect(
+          EmployeeContractInfo.validateFinalDate('$day/$month/$year'), isNull);
     });
   });
 }

--- a/client/rufino_v2/test/unit/ui/features/employee/employee_profile_viewmodel_test.dart
+++ b/client/rufino_v2/test/unit/ui/features/employee/employee_profile_viewmodel_test.dart
@@ -1077,21 +1077,38 @@ void main() {
         expect(viewModel.contractsStatus, SectionLoadStatus.error);
       });
 
-      test('validateContractDate returns null for a valid recent date', () {
-        // Today's date should be valid (within ±365 days).
+      test('validateContractInitDate returns null for a valid recent date', () {
         final now = DateTime.now();
         final formatted =
             '${now.day.toString().padLeft(2, '0')}/${now.month.toString().padLeft(2, '0')}/${now.year}';
-        expect(viewModel.validateContractDate(formatted), isNull);
+        expect(viewModel.validateContractInitDate(formatted), isNull);
       });
 
-      test('validateContractDate returns error for empty input', () {
-        expect(viewModel.validateContractDate(''), isNotNull);
+      test('validateContractInitDate returns error for empty input', () {
+        expect(viewModel.validateContractInitDate(''), isNotNull);
       });
 
-      test('validateContractDate returns error for a date beyond ±365 days',
+      test('validateContractInitDate returns error for a date beyond range',
           () {
-        expect(viewModel.validateContractDate('01/01/2020'), isNotNull);
+        // A date more than 12 years ago should fail.
+        expect(viewModel.validateContractInitDate('01/01/2010'), isNotNull);
+      });
+
+      test('validateContractFinalDate returns null for a valid recent date',
+          () {
+        final now = DateTime.now();
+        final formatted =
+            '${now.day.toString().padLeft(2, '0')}/${now.month.toString().padLeft(2, '0')}/${now.year}';
+        expect(viewModel.validateContractFinalDate(formatted), isNull);
+      });
+
+      test('validateContractFinalDate returns error for empty input', () {
+        expect(viewModel.validateContractFinalDate(''), isNotNull);
+      });
+
+      test('validateContractFinalDate returns error for a date beyond ±1 year',
+          () {
+        expect(viewModel.validateContractFinalDate('01/01/2020'), isNotNull);
       });
     });
 

--- a/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/EmployeeAggregate/EmploymentContract.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/EmployeeAggregate/EmploymentContract.cs
@@ -5,7 +5,9 @@ namespace PeopleManagement.Domain.AggregatesModel.EmployeeAggregate
 {
     public sealed class EmploymentContract : ValueObject
     {
-        public int MAX_RANGE_DATE_YEARS = 1;
+        public int MAX_DATE_INIT_YEARS_MIN = 12;
+        public int MAX_DATE_INIT_YEARS_MAX = 1;
+        public int MAX_RANGE_DATE_FINAL_YEARS = 1;
 
         private DateOnly _initDate;
         private DateOnly? _finalDate = null;
@@ -18,8 +20,8 @@ namespace PeopleManagement.Domain.AggregatesModel.EmployeeAggregate
             {
 
                 var dateNow = DateOnly.FromDateTime(DateTime.UtcNow);
-                var dateMax = dateNow.AddYears(MAX_RANGE_DATE_YEARS);
-                var dateMin = dateNow.AddYears(MAX_RANGE_DATE_YEARS * -1);
+                var dateMax = dateNow.AddYears(MAX_DATE_INIT_YEARS_MAX);
+                var dateMin = dateNow.AddYears(MAX_DATE_INIT_YEARS_MIN * -1);
                 if (value < dateMin || value > dateMax)
                     throw new DomainException(this.GetType().Name, DomainErrors.DataHasBeBetween(nameof(InitDate), value, dateMin, dateMax));
                 _initDate = value;
@@ -33,8 +35,8 @@ namespace PeopleManagement.Domain.AggregatesModel.EmployeeAggregate
                 if (value != null)
                 {
                     var dateNow = DateOnly.FromDateTime(DateTime.UtcNow);
-                    var dateMax = dateNow.AddYears(MAX_RANGE_DATE_YEARS);
-                    var dateMin = dateNow.AddYears(MAX_RANGE_DATE_YEARS * -1);
+                    var dateMax = dateNow.AddYears(MAX_RANGE_DATE_FINAL_YEARS);
+                    var dateMin = dateNow.AddYears(MAX_RANGE_DATE_FINAL_YEARS * -1);
                     if (value < dateMin || value > dateMax)
                         throw new DomainException(this.GetType().Name, DomainErrors.DataHasBeBetween(nameof(FinalDate), (DateOnly)value, dateMin, dateMax));
                     _finalDate = value;


### PR DESCRIPTION
  - EmployeeContractInfo: substitui validateDate (±365 dias) por validateInitDate (-12 anos/+1 ano) e validateFinalDate (±1 ano), espelhando as regras do EmploymentContract.cs no backend
  - DocumentUnit: adiciona validateDate com validação apenas de formato, sem restrição de range, conforme regra de domínio do backend
  - contract_section: usa validateContractInitDate e validateContractFinalDate nos campos correspondentes
  - documents_section: usa validateDocumentUnitDate em vez de validateContractDate
  - Atualiza testes unitários das entidades e do viewmodel