### PR TITLE
Add combine files feature to batch download wizard

### DIFF
--- a/client/rufino_v2/android/app/build.gradle.kts
+++ b/client/rufino_v2/android/app/build.gradle.kts
@@ -35,6 +35,10 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/client/rufino_v2/android/app/proguard-rules.pro
+++ b/client/rufino_v2/android/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+# Google ML Kit Text Recognition
+-keep class com.google.mlkit.vision.text.** { *; }
+-keep class com.google.mlkit.vision.text.chinese.** { *; }
+-keep class com.google.mlkit.vision.text.devanagari.** { *; }
+-keep class com.google.mlkit.vision.text.japanese.** { *; }
+-keep class com.google.mlkit.vision.text.korean.** { *; }
+
+# General ML Kit
+-keep class com.google.mlkit.** { *; }
+-dontwarn com.google.mlkit.**

--- a/client/rufino_v2/lib/core/utils/combine_file_namer.dart
+++ b/client/rufino_v2/lib/core/utils/combine_file_namer.dart
@@ -1,0 +1,25 @@
+import '../../domain/entities/batch_download.dart';
+
+/// Builds the combined PDF file name following the backend naming pattern.
+///
+/// The pattern is `{YYYY_MM_DD}-{EMPLOYEE}-{DOCUMENT}-{idSuffix}.PDF`,
+/// mirroring `BatchDownloadQueries.DownloadBatchDocumentUnits` in the server.
+/// All segments are UPPERCASED and spaces are replaced with underscores.
+///
+/// Uses the [firstUnit]'s date, employee name, template name, and the last
+/// 4 characters of its document unit ID as the suffix.
+String buildCombinedFileName(BatchDownloadUnit firstUnit) {
+  final dateParts = firstUnit.date.split('/');
+  final formattedDate = '${dateParts[2]}_${dateParts[1]}_${dateParts[0]}';
+
+  final employeeSegment =
+      firstUnit.employeeName.trim().replaceAll(' ', '_').toUpperCase();
+  final documentSegment =
+      firstUnit.documentTemplateName.trim().replaceAll(' ', '_').toUpperCase();
+
+  final id = firstUnit.documentUnitId;
+  final idSuffix =
+      id.length >= 4 ? id.substring(id.length - 4).toUpperCase() : id.toUpperCase();
+
+  return '$formattedDate-$employeeSegment-$documentSegment-$idSuffix.PDF';
+}

--- a/client/rufino_v2/lib/core/utils/zip_builder.dart
+++ b/client/rufino_v2/lib/core/utils/zip_builder.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+
+/// A named pair of file name and raw bytes for a ZIP entry.
+typedef ZipEntry = ({String fileName, Uint8List bytes});
+
+/// Builds a ZIP archive in memory from the given [entries].
+///
+/// Each entry becomes a file inside the archive, stored with fastest
+/// compression for speed. Returns the raw ZIP bytes.
+Uint8List buildZipFromEntries(List<ZipEntry> entries) {
+  final archive = Archive();
+  for (final entry in entries) {
+    archive.addFile(
+      ArchiveFile.bytes(entry.fileName, entry.bytes),
+    );
+  }
+  final encoded = ZipEncoder().encode(archive);
+  return Uint8List.fromList(encoded);
+}

--- a/client/rufino_v2/lib/data/repositories/batch_download_repository_impl.dart
+++ b/client/rufino_v2/lib/data/repositories/batch_download_repository_impl.dart
@@ -110,4 +110,26 @@ class BatchDownloadRepositoryImpl implements BatchDownloadRepository {
       return Result.error(BatchDownloadNetworkException(e));
     }
   }
+
+  @override
+  Future<Result<Uint8List>> downloadDocumentUnit(
+    String companyId,
+    String employeeId,
+    String documentId,
+    String documentUnitId,
+  ) async {
+    try {
+      final bytes = await apiService.downloadDocumentUnit(
+        companyId,
+        employeeId,
+        documentId,
+        documentUnitId,
+      );
+      return Result.success(bytes);
+    } on BatchDownloadException catch (e) {
+      return Result.error(e);
+    } catch (e) {
+      return Result.error(BatchDownloadNetworkException(e));
+    }
+  }
 }

--- a/client/rufino_v2/lib/data/services/batch_download_api_service.dart
+++ b/client/rufino_v2/lib/data/services/batch_download_api_service.dart
@@ -115,6 +115,24 @@ class BatchDownloadApiService {
     return BatchDownloadUnitsResponse.fromJson(json);
   }
 
+  /// Downloads a single document unit file.
+  ///
+  /// Returns the raw file bytes.
+  Future<Uint8List> downloadDocumentUnit(
+    String companyId,
+    String employeeId,
+    String documentId,
+    String documentUnitId,
+  ) async {
+    final uri = Uri.https(
+      baseUrl,
+      '/api/v1/$companyId/document/download/$employeeId/$documentId/$documentUnitId',
+    );
+    final response = await client.get(uri, headers: await _headers());
+    checkHttpStatus(response);
+    return response.bodyBytes;
+  }
+
   /// Downloads the selected document units as a ZIP file.
   ///
   /// Returns the raw ZIP bytes.

--- a/client/rufino_v2/lib/domain/entities/batch_download.dart
+++ b/client/rufino_v2/lib/domain/entities/batch_download.dart
@@ -113,6 +113,25 @@ class BatchDownloadUnit {
   String get selectionKey => '$documentId:$documentUnitId';
 }
 
+/// A numbered group of document units selected in one round of the
+/// combination wizard.
+///
+/// Each round of unit selection in step 2 produces one group. Groups are
+/// merged per employee in order during the combine download.
+class CombinationGroup {
+  /// Creates a [CombinationGroup] with the given [groupNumber] and [units].
+  const CombinationGroup({
+    required this.groupNumber,
+    required this.units,
+  });
+
+  /// The 1-based position of this group in the combination sequence.
+  final int groupNumber;
+
+  /// The document units selected in this round.
+  final List<BatchDownloadUnit> units;
+}
+
 /// Paginated result of employees for batch download.
 class BatchDownloadEmployeesPage {
   const BatchDownloadEmployeesPage({

--- a/client/rufino_v2/lib/domain/repositories/batch_download_repository.dart
+++ b/client/rufino_v2/lib/domain/repositories/batch_download_repository.dart
@@ -49,4 +49,15 @@ abstract class BatchDownloadRepository {
     String companyId,
     List<BatchDownloadItem> items,
   );
+
+  /// Downloads a single document unit file.
+  ///
+  /// Returns the raw file bytes for the unit identified by [documentUnitId]
+  /// within [documentId] for [employeeId].
+  Future<Result<Uint8List>> downloadDocumentUnit(
+    String companyId,
+    String employeeId,
+    String documentId,
+    String documentUnitId,
+  );
 }

--- a/client/rufino_v2/lib/ui/features/batch_download/viewmodel/batch_download_viewmodel.dart
+++ b/client/rufino_v2/lib/ui/features/batch_download/viewmodel/batch_download_viewmodel.dart
@@ -1,8 +1,9 @@
 import 'dart:collection';
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 
+import '../../../../core/utils/combine_file_namer.dart';
+import '../../../../core/utils/pdf_merger.dart';
+import '../../../../core/utils/zip_builder.dart';
 import '../../../../domain/entities/batch_download.dart';
 import '../../../../domain/entities/document_group_with_templates.dart';
 import '../../../../domain/entities/workplace.dart';
@@ -221,6 +222,68 @@ class BatchDownloadViewModel extends ChangeNotifier {
 
   // We cache all loaded units so the review step can display them
   final List<BatchDownloadUnit> _allLoadedUnits = [];
+
+  // ---------------------------------------------------------------------------
+  // Combination state
+  // ---------------------------------------------------------------------------
+
+  final List<CombinationGroup> _combinationGroups = [];
+
+  /// The committed combination groups.
+  UnmodifiableListView<CombinationGroup> get combinationGroups =>
+      UnmodifiableListView(_combinationGroups);
+
+  /// Whether the wizard is in combine mode.
+  bool get isCombineMode => _combinationGroups.isNotEmpty;
+
+  /// The number of committed combination groups.
+  int get combinationGroupCount => _combinationGroups.length;
+
+  /// Total units across all committed combination groups.
+  int get combinedTotalUnitCount =>
+      _combinationGroups.fold(0, (sum, g) => sum + g.units.length);
+
+  double _downloadProgress = 0.0;
+
+  /// Download progress from 0.0 to 1.0 during combine download.
+  double get downloadProgress => _downloadProgress;
+
+  /// Returns the combination groups organized by employee for the review UI.
+  ///
+  /// Each employee maps to a list of groups containing only that employee's
+  /// units. Groups with no units for a given employee are omitted.
+  Map<String, List<CombinationGroup>> get combinedUnitsByEmployee {
+    final result = <String, List<CombinationGroup>>{};
+    for (final group in _combinationGroups) {
+      final byEmployee = <String, List<BatchDownloadUnit>>{};
+      for (final unit in group.units) {
+        byEmployee.putIfAbsent(unit.employeeName, () => []).add(unit);
+      }
+      for (final entry in byEmployee.entries) {
+        result.putIfAbsent(entry.key, () => []).add(
+              CombinationGroup(
+                groupNumber: group.groupNumber,
+                units: entry.value,
+              ),
+            );
+      }
+    }
+    return result;
+  }
+
+  /// The number of distinct employees across all combination groups.
+  int get combinedEmployeeCount => combinedUnitsByEmployee.keys.length;
+
+  /// The file name for a single-employee combined PDF.
+  ///
+  /// Uses the first unit of the first group to derive the name following
+  /// the backend naming pattern.
+  String get combinedFileName {
+    if (_combinationGroups.isEmpty || _combinationGroups.first.units.isEmpty) {
+      return 'documentos_combinados.pdf';
+    }
+    return buildCombinedFileName(_combinationGroups.first.units.first);
+  }
 
   // ---------------------------------------------------------------------------
   // Data loading
@@ -531,6 +594,7 @@ class BatchDownloadViewModel extends ChangeNotifier {
     _unitPageNumber = 1;
     _allLoadedUnits.clear();
     _selectedUnitKeys.clear();
+    _combinationGroups.clear();
     notifyListeners();
     await Future.wait([
       loadDocumentUnits(),
@@ -539,8 +603,16 @@ class BatchDownloadViewModel extends ChangeNotifier {
   }
 
   /// Advances from step 2 to step 3 (review).
+  ///
+  /// In combine mode, auto-adds the current selection as the last group
+  /// if any units are selected. Proceeds if at least one group exists.
   void proceedToReview() {
-    if (!hasSelectedUnits) return;
+    if (isCombineMode) {
+      if (hasSelectedUnits) addToCombination();
+      if (_combinationGroups.isEmpty) return;
+    } else {
+      if (!hasSelectedUnits) return;
+    }
     _currentStep = BatchDownloadStep.review;
     _status = BatchDownloadStatus.loaded;
     notifyListeners();
@@ -604,6 +676,154 @@ class BatchDownloadViewModel extends ChangeNotifier {
     } catch (e) {
       _status = BatchDownloadStatus.error;
       _errorMessage = 'Erro ao baixar documentos';
+      notifyListeners();
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combination
+  // ---------------------------------------------------------------------------
+
+  /// Saves the current unit selection as a numbered combination group.
+  ///
+  /// Clears the current selection so the user can start a new round.
+  void addToCombination() {
+    if (!hasSelectedUnits) return;
+
+    final units = _allLoadedUnits
+        .where((u) => _selectedUnitKeys.contains(u.selectionKey))
+        .toList();
+
+    _combinationGroups.add(CombinationGroup(
+      groupNumber: _combinationGroups.length + 1,
+      units: units,
+    ));
+
+    _selectedUnitKeys.clear();
+    notifyListeners();
+  }
+
+  /// Removes a combination group and renumbers the remaining ones.
+  void removeCombinationGroup(int groupNumber) {
+    _combinationGroups.removeWhere((g) => g.groupNumber == groupNumber);
+    for (var i = 0; i < _combinationGroups.length; i++) {
+      _combinationGroups[i] = CombinationGroup(
+        groupNumber: i + 1,
+        units: _combinationGroups[i].units,
+      );
+    }
+    notifyListeners();
+  }
+
+  /// Downloads individual document files and merges them per employee.
+  ///
+  /// Returns the merged PDF bytes for a single employee, or a ZIP of
+  /// merged PDFs for multiple employees. Returns null on error.
+  Future<Uint8List?> downloadCombined() async {
+    if (_combinationGroups.isEmpty) return null;
+
+    _status = BatchDownloadStatus.downloading;
+    _downloadProgress = 0.0;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      // Collect all unique units across groups preserving group order.
+      final allUnits = _combinationGroups
+          .expand((g) => g.units)
+          .toList();
+
+      // Download each file individually with limited concurrency.
+      final downloadedBytes = <String, Uint8List>{};
+      const concurrencyLimit = 5;
+      var completed = 0;
+
+      for (var i = 0; i < allUnits.length; i += concurrencyLimit) {
+        final batch = allUnits.skip(i).take(concurrencyLimit);
+        final futures = batch.map((unit) async {
+          final key = unit.selectionKey;
+          if (downloadedBytes.containsKey(key)) return;
+          final result = await _batchDownloadRepository.downloadDocumentUnit(
+            _companyId,
+            unit.employeeId,
+            unit.documentId,
+            unit.documentUnitId,
+          );
+          result.fold(
+            onSuccess: (bytes) => downloadedBytes[key] = bytes,
+            onError: (e) => throw Exception(
+              'Falha ao baixar ${unit.documentTemplateName}: $e',
+            ),
+          );
+        });
+        await Future.wait(futures);
+        completed += batch.length;
+        _downloadProgress = completed / allUnits.length;
+        notifyListeners();
+      }
+
+      // Build per-employee PDF entries in group order.
+      final byEmployee = combinedUnitsByEmployee;
+      final mergedFiles = <ZipEntry>[];
+
+      for (final entry in byEmployee.entries) {
+        final employeeName = entry.key;
+        final employeeGroups = entry.value;
+
+        final pdfEntries = <PdfFileEntry>[];
+        BatchDownloadUnit? firstUnit;
+        for (final group in employeeGroups) {
+          for (final unit in group.units) {
+            firstUnit ??= unit;
+            final bytes = downloadedBytes[unit.selectionKey];
+            if (bytes != null) {
+              pdfEntries.add(PdfFileEntry(
+                name: '${unit.documentTemplateName}_${unit.date}',
+                bytes: bytes,
+              ));
+            }
+          }
+        }
+
+        if (pdfEntries.isEmpty) continue;
+
+        final mergeResult = await mergePdfFiles(pdfEntries);
+        late final Uint8List merged;
+        mergeResult.fold(
+          onSuccess: (bytes) => merged = bytes,
+          onError: (error) => throw Exception(
+            'Erro ao combinar PDFs de $employeeName: $error',
+          ),
+        );
+
+        final fileName = firstUnit != null
+            ? buildCombinedFileName(firstUnit)
+            : '${employeeName.replaceAll(' ', '_').toUpperCase()}.PDF';
+
+        mergedFiles.add((fileName: fileName, bytes: merged));
+      }
+
+      if (mergedFiles.isEmpty) {
+        _status = BatchDownloadStatus.error;
+        _errorMessage = 'Nenhum arquivo para combinar';
+        notifyListeners();
+        return null;
+      }
+
+      final Uint8List resultBytes;
+      if (mergedFiles.length == 1) {
+        resultBytes = mergedFiles.first.bytes;
+      } else {
+        resultBytes = buildZipFromEntries(mergedFiles);
+      }
+
+      _status = BatchDownloadStatus.downloadComplete;
+      notifyListeners();
+      return resultBytes;
+    } catch (e) {
+      _status = BatchDownloadStatus.error;
+      _errorMessage = e.toString();
       notifyListeners();
       return null;
     }

--- a/client/rufino_v2/lib/ui/features/batch_download/widgets/batch_download_screen.dart
+++ b/client/rufino_v2/lib/ui/features/batch_download/widgets/batch_download_screen.dart
@@ -5,6 +5,7 @@ import '../../../../core/theme/app_breakpoints.dart';
 import '../../../../core/theme/app_spacing.dart';
 import '../../../../core/utils/file_saver.dart';
 import '../viewmodel/batch_download_viewmodel.dart';
+import 'combine_review_step.dart';
 import 'employee_selection_step.dart';
 import 'review_download_step.dart';
 import 'unit_selection_step.dart';
@@ -70,6 +71,28 @@ class _BatchDownloadScreenState extends State<BatchDownloadScreen> {
     }
   }
 
+  Future<void> _handleCombineDownload() async {
+    final vm = widget.viewModel;
+    final bytes = await vm.downloadCombined();
+    if (bytes != null && mounted) {
+      final isSingleEmployee = vm.combinedEmployeeCount == 1;
+      final fileName = isSingleEmployee
+          ? vm.combinedFileName
+          : 'documentos_combinados.zip';
+      await saveFile(fileName: fileName, bytes: bytes);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(
+              content: Text('Combinacao concluida com sucesso!'),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final vm = widget.viewModel;
@@ -110,10 +133,15 @@ class _BatchDownloadScreenState extends State<BatchDownloadScreen> {
                       viewModel: vm,
                       onNext: vm.proceedToReview,
                     ),
-                  BatchDownloadStep.review => ReviewDownloadStep(
-                      viewModel: vm,
-                      onDownload: _handleDownload,
-                    ),
+                  BatchDownloadStep.review => vm.isCombineMode
+                      ? CombineReviewStep(
+                          viewModel: vm,
+                          onDownload: _handleCombineDownload,
+                        )
+                      : ReviewDownloadStep(
+                          viewModel: vm,
+                          onDownload: _handleDownload,
+                        ),
                 },
               ),
             ),

--- a/client/rufino_v2/lib/ui/features/batch_download/widgets/combine_review_step.dart
+++ b/client/rufino_v2/lib/ui/features/batch_download/widgets/combine_review_step.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_spacing.dart';
+import '../../../../domain/entities/batch_download.dart';
+import '../viewmodel/batch_download_viewmodel.dart';
+
+/// Step 3 (combine mode): Review combination groups and download merged PDFs.
+///
+/// Displays the committed groups organized per employee, with a progress
+/// indicator during download and a "Combinar e Baixar" action button.
+class CombineReviewStep extends StatelessWidget {
+  const CombineReviewStep({
+    super.key,
+    required this.viewModel,
+    required this.onDownload,
+  });
+
+  /// The parent view model.
+  final BatchDownloadViewModel viewModel;
+
+  /// Callback invoked when the user taps "Combinar e Baixar".
+  final VoidCallback onDownload;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = viewModel;
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final byEmployee = vm.combinedUnitsByEmployee;
+    final isDownloading = vm.status == BatchDownloadStatus.downloading;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSpacing.md),
+        // Summary
+        Card.filled(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.merge_type_rounded,
+                  size: 32,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '${vm.combinationGroupCount} grupo(s), '
+                        '${vm.combinedTotalUnitCount} documento(s)',
+                        style: textTheme.titleMedium,
+                      ),
+                      Text(
+                        'de ${vm.combinedEmployeeCount} funcionario(s)',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        // Progress indicator
+        if (isDownloading) ...[
+          LinearProgressIndicator(value: vm.downloadProgress),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Baixando e combinando... ${(vm.downloadProgress * 100).toInt()}%',
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+        // Grouped list by employee
+        Expanded(
+          child: byEmployee.isEmpty
+              ? Center(
+                  child: Text(
+                    'Nenhum documento na combinacao',
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: byEmployee.length,
+                  itemBuilder: (context, index) {
+                    final entry = byEmployee.entries.elementAt(index);
+                    return _EmployeeCombineCard(
+                      employeeName: entry.key,
+                      groups: entry.value,
+                      onRemoveGroup: isDownloading
+                          ? null
+                          : (groupNumber) =>
+                              vm.removeCombinationGroup(groupNumber),
+                    );
+                  },
+                ),
+        ),
+        // Navigation + Download
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              OutlinedButton(
+                onPressed: isDownloading ? null : vm.goBack,
+                child: const Text('Voltar'),
+              ),
+              isDownloading
+                  ? const SizedBox(
+                      width: 180,
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  : FilledButton.icon(
+                      onPressed: vm.combinationGroupCount > 0
+                          ? onDownload
+                          : null,
+                      icon: const Icon(Icons.merge_type_rounded, size: 18),
+                      label: const Text('Combinar e Baixar'),
+                    ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Displays one employee's combination groups with numbered sections.
+class _EmployeeCombineCard extends StatelessWidget {
+  const _EmployeeCombineCard({
+    required this.employeeName,
+    required this.groups,
+    required this.onRemoveGroup,
+  });
+
+  final String employeeName;
+  final List<CombinationGroup> groups;
+  final void Function(int groupNumber)? onRemoveGroup;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card.outlined(
+      margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              employeeName,
+              style: textTheme.titleSmall?.copyWith(
+                color: colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            ...groups.map(
+              (group) => Padding(
+                padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          'Grupo ${group.groupNumber}',
+                          style: textTheme.labelMedium?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (onRemoveGroup != null) ...[
+                          const SizedBox(width: AppSpacing.xs),
+                          InkWell(
+                            onTap: () => onRemoveGroup!(group.groupNumber),
+                            borderRadius: BorderRadius.circular(12),
+                            child: Padding(
+                              padding: const EdgeInsets.all(2),
+                              child: Icon(
+                                Icons.close,
+                                size: 14,
+                                color: colorScheme.error,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    ...group.units.map(
+                      (unit) => Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 2,
+                          horizontal: AppSpacing.sm,
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              Icons.description_outlined,
+                              size: 16,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            const SizedBox(width: AppSpacing.xs),
+                            Expanded(
+                              child: Text(
+                                '${unit.documentTemplateName} - ${unit.date}'
+                                '${unit.period != null ? ' (${unit.period!.formattedPeriod})' : ''}',
+                                style: textTheme.bodySmall,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/rufino_v2/lib/ui/features/batch_download/widgets/unit_selection_step.dart
+++ b/client/rufino_v2/lib/ui/features/batch_download/widgets/unit_selection_step.dart
@@ -107,6 +107,24 @@ class _UnitSelectionStepState extends State<UnitSelectionStep> {
           onPeriodTypeChanged: _onPeriodTypeChanged,
         ),
         const SizedBox(height: AppSpacing.sm),
+        // Combination indicator
+        if (vm.isCombineMode)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+            child: Chip(
+              avatar: Icon(
+                Icons.merge_type_rounded,
+                size: 18,
+                color: colorScheme.primary,
+              ),
+              label: Text(
+                '${vm.combinationGroupCount} grupo(s) | '
+                '${vm.combinedTotalUnitCount} documento(s)',
+              ),
+              backgroundColor: colorScheme.primaryContainer,
+              side: BorderSide.none,
+            ),
+          ),
         // Clear + selection actions
         Row(
           children: [
@@ -232,8 +250,18 @@ class _UnitSelectionStepState extends State<UnitSelectionStep> {
                     child: const Text('Voltar'),
                   ),
                   const SizedBox(width: AppSpacing.sm),
+                  OutlinedButton.icon(
+                    onPressed: vm.hasSelectedUnits
+                        ? vm.addToCombination
+                        : null,
+                    icon: const Icon(Icons.playlist_add, size: 18),
+                    label: const Text('Adicionar a combinacao'),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
                   FilledButton.icon(
-                    onPressed: vm.hasSelectedUnits ? widget.onNext : null,
+                    onPressed: vm.hasSelectedUnits || vm.isCombineMode
+                        ? widget.onNext
+                        : null,
                     icon: const Icon(Icons.arrow_forward, size: 18),
                     label: const Text('Proximo'),
                   ),

--- a/client/rufino_v2/pubspec.lock
+++ b/client/rufino_v2/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff

--- a/client/rufino_v2/pubspec.yaml
+++ b/client/rufino_v2/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   shared_preferences: ^2.5.5
   uuid: ^4.5.3
   pdf_combiner: ^6.0.4
+  archive: ^4.0.2
 
 dev_dependencies:
   flutter_test:

--- a/client/rufino_v2/test/testing/fakes/fake_batch_download_repository.dart
+++ b/client/rufino_v2/test/testing/fakes/fake_batch_download_repository.dart
@@ -24,6 +24,12 @@ class FakeBatchDownloadRepository implements BatchDownloadRepository {
   /// The ZIP bytes to return from [downloadBatch].
   Uint8List downloadBytes = Uint8List(0);
 
+  /// Bytes to return from [downloadDocumentUnit], keyed by `documentId:documentUnitId`.
+  Map<String, Uint8List> documentUnitBytes = {};
+
+  /// Tracks the keys of units downloaded via [downloadDocumentUnit].
+  List<String> downloadedUnitKeys = [];
+
   /// When non-null, all methods return [Result.error] with this value.
   Object? errorToThrow;
 
@@ -102,5 +108,19 @@ class FakeBatchDownloadRepository implements BatchDownloadRepository {
     lastDownloadItems = items;
     if (errorToThrow != null) return Result.error(errorToThrow!);
     return Result.success(downloadBytes);
+  }
+
+  @override
+  Future<Result<Uint8List>> downloadDocumentUnit(
+    String companyId,
+    String employeeId,
+    String documentId,
+    String documentUnitId,
+  ) async {
+    final key = '$documentId:$documentUnitId';
+    downloadedUnitKeys.add(key);
+    if (errorToThrow != null) return Result.error(errorToThrow!);
+    final bytes = documentUnitBytes[key] ?? Uint8List(0);
+    return Result.success(bytes);
   }
 }

--- a/client/rufino_v2/test/unit/core/utils/combine_file_namer_test.dart
+++ b/client/rufino_v2/test/unit/core/utils/combine_file_namer_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rufino_v2/core/utils/combine_file_namer.dart';
+import 'package:rufino_v2/domain/entities/batch_download.dart';
+
+void main() {
+  group('buildCombinedFileName', () {
+    test('formats standard case with date, employee, template and suffix', () {
+      const unit = BatchDownloadUnit(
+        documentUnitId: 'abc12345-6789-0000-0000-000000001234',
+        documentId: 'doc-1',
+        employeeId: 'emp-1',
+        employeeName: 'Alice Silva',
+        documentTemplateName: 'Holerite',
+        date: '28/02/2026',
+        statusId: 2,
+        statusName: 'OK',
+        documentGroupName: 'RH',
+        hasFile: true,
+      );
+
+      final result = buildCombinedFileName(unit);
+
+      expect(result, '2026_02_28-ALICE_SILVA-HOLERITE-1234.PDF');
+    });
+
+    test('replaces spaces with underscores in multi-word names', () {
+      const unit = BatchDownloadUnit(
+        documentUnitId: 'aaaa-bbbb-cccc-dddd-eeee5678',
+        documentId: 'doc-2',
+        employeeId: 'emp-2',
+        employeeName: 'Maria Aparecida dos Santos',
+        documentTemplateName: 'Contrato de Trabalho',
+        date: '01/12/2025',
+        statusId: 2,
+        statusName: 'OK',
+        documentGroupName: 'Admissao',
+        hasFile: true,
+      );
+
+      final result = buildCombinedFileName(unit);
+
+      expect(
+        result,
+        '2025_12_01-MARIA_APARECIDA_DOS_SANTOS-CONTRATO_DE_TRABALHO-5678.PDF',
+      );
+    });
+
+    test('handles short document unit ID', () {
+      const unit = BatchDownloadUnit(
+        documentUnitId: 'ab',
+        documentId: 'doc-3',
+        employeeId: 'emp-3',
+        employeeName: 'Bob',
+        documentTemplateName: 'ASO',
+        date: '05/01/2026',
+        statusId: 1,
+        statusName: 'Pending',
+        documentGroupName: 'SST',
+        hasFile: true,
+      );
+
+      final result = buildCombinedFileName(unit);
+
+      expect(result, '2026_01_05-BOB-ASO-AB.PDF');
+    });
+
+    test('uppercases all segments including suffix', () {
+      const unit = BatchDownloadUnit(
+        documentUnitId: 'lower-case-id-abcd',
+        documentId: 'doc-4',
+        employeeId: 'emp-4',
+        employeeName: 'joao',
+        documentTemplateName: 'recibo',
+        date: '15/06/2026',
+        statusId: 2,
+        statusName: 'OK',
+        documentGroupName: 'Financeiro',
+        hasFile: true,
+      );
+
+      final result = buildCombinedFileName(unit);
+
+      expect(result, '2026_06_15-JOAO-RECIBO-ABCD.PDF');
+    });
+  });
+}

--- a/client/rufino_v2/test/unit/ui/features/batch_download/batch_download_viewmodel_test.dart
+++ b/client/rufino_v2/test/unit/ui/features/batch_download/batch_download_viewmodel_test.dart
@@ -333,4 +333,239 @@ void main() {
       expect(viewModel.errorMessage, isNotNull);
     });
   });
+
+  group('Combination mode', () {
+    Future<void> navigateToStep2() async {
+      await viewModel.initialize();
+      viewModel.toggleEmployeeSelection('emp-1');
+      viewModel.toggleEmployeeSelection('emp-2');
+      await viewModel.proceedToUnitSelection();
+    }
+
+    test('addToCombination creates a group and clears selection', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      expect(viewModel.selectedUnitCount, 1);
+
+      viewModel.addToCombination();
+
+      expect(viewModel.combinationGroupCount, 1);
+      expect(viewModel.combinationGroups.first.groupNumber, 1);
+      expect(viewModel.combinationGroups.first.units.length, 1);
+      expect(viewModel.selectedUnitCount, 0);
+    });
+
+    test('addToCombination does nothing when no units selected', () async {
+      await navigateToStep2();
+
+      viewModel.addToCombination();
+
+      expect(viewModel.combinationGroupCount, 0);
+      expect(viewModel.isCombineMode, false);
+    });
+
+    test('isCombineMode returns true after adding a group', () async {
+      await navigateToStep2();
+      expect(viewModel.isCombineMode, false);
+
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+
+      expect(viewModel.isCombineMode, true);
+    });
+
+    test('multiple groups maintain order and numbering', () async {
+      // Use units that have hasFile=true for both
+      fakeBatchDownloadRepo.unitsPage = BatchDownloadUnitsPage(
+        items: [
+          testUnits[0], // unit-1, hasFile=true
+          const BatchDownloadUnit(
+            documentUnitId: 'unit-3',
+            documentId: 'doc-3',
+            employeeId: 'emp-1',
+            employeeName: 'Alice Silva',
+            documentTemplateName: 'Contrato',
+            documentGroupName: 'RH',
+            date: '01/03/2026',
+            statusId: 2,
+            statusName: 'OK',
+            hasFile: true,
+          ),
+        ],
+        totalCount: 2,
+      );
+      await navigateToStep2();
+
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+
+      viewModel.toggleUnitSelection('doc-3', 'unit-3');
+      viewModel.addToCombination();
+
+      expect(viewModel.combinationGroupCount, 2);
+      expect(viewModel.combinationGroups[0].groupNumber, 1);
+      expect(viewModel.combinationGroups[1].groupNumber, 2);
+      expect(viewModel.combinedTotalUnitCount, 2);
+    });
+
+    test('proceedToReview auto-adds current selection in combine mode',
+        () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+
+      // Simulate loading new units
+      fakeBatchDownloadRepo.unitsPage = const BatchDownloadUnitsPage(
+        items: [
+          BatchDownloadUnit(
+            documentUnitId: 'unit-4',
+            documentId: 'doc-4',
+            employeeId: 'emp-1',
+            employeeName: 'Alice Silva',
+            documentTemplateName: 'ASO',
+            documentGroupName: 'SST',
+            date: '10/03/2026',
+            statusId: 2,
+            statusName: 'OK',
+            hasFile: true,
+          ),
+        ],
+        totalCount: 1,
+      );
+      await viewModel.loadDocumentUnits();
+
+      viewModel.toggleUnitSelection('doc-4', 'unit-4');
+      viewModel.proceedToReview();
+
+      expect(viewModel.combinationGroupCount, 2);
+      expect(viewModel.currentStep, BatchDownloadStep.review);
+    });
+
+    test('proceedToReview in normal mode works unchanged', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+
+      viewModel.proceedToReview();
+
+      expect(viewModel.isCombineMode, false);
+      expect(viewModel.currentStep, BatchDownloadStep.review);
+    });
+
+    test('removeCombinationGroup removes and renumbers', () async {
+      await navigateToStep2();
+
+      // Add 3 groups
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      expect(viewModel.combinationGroupCount, 3);
+
+      viewModel.removeCombinationGroup(2);
+
+      expect(viewModel.combinationGroupCount, 2);
+      expect(viewModel.combinationGroups[0].groupNumber, 1);
+      expect(viewModel.combinationGroups[1].groupNumber, 2);
+    });
+
+    test('goBack from combine review preserves groups', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      viewModel.proceedToReview();
+
+      expect(viewModel.currentStep, BatchDownloadStep.review);
+      viewModel.goBack();
+
+      expect(viewModel.currentStep, BatchDownloadStep.selectUnits);
+      expect(viewModel.isCombineMode, true);
+      expect(viewModel.combinationGroupCount, 1);
+    });
+
+    test('proceedToUnitSelection resets combination state', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      expect(viewModel.isCombineMode, true);
+
+      viewModel.goBack(); // back to step 1
+      await viewModel.proceedToUnitSelection();
+
+      expect(viewModel.isCombineMode, false);
+      expect(viewModel.combinationGroupCount, 0);
+    });
+
+    test('combinedUnitsByEmployee groups units by employee', () async {
+      fakeBatchDownloadRepo.unitsPage = BatchDownloadUnitsPage(
+        items: [
+          testUnits[0], // emp-1 Alice
+          const BatchDownloadUnit(
+            documentUnitId: 'unit-5',
+            documentId: 'doc-5',
+            employeeId: 'emp-2',
+            employeeName: 'Bob Santos',
+            documentTemplateName: 'Holerite',
+            documentGroupName: 'RH',
+            date: '28/02/2026',
+            statusId: 2,
+            statusName: 'OK',
+            hasFile: true,
+          ),
+        ],
+        totalCount: 2,
+      );
+      await navigateToStep2();
+
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.toggleUnitSelection('doc-5', 'unit-5');
+      viewModel.addToCombination();
+
+      final byEmployee = viewModel.combinedUnitsByEmployee;
+      expect(byEmployee.keys, containsAll(['Alice Silva', 'Bob Santos']));
+      expect(byEmployee['Alice Silva']?.first.units.length, 1);
+      expect(byEmployee['Bob Santos']?.first.units.length, 1);
+    });
+
+    test('downloadCombined calls individual download for each unit', () async {
+      fakeBatchDownloadRepo.documentUnitBytes = {
+        'doc-1:unit-1': Uint8List.fromList([0x25, 0x50, 0x44, 0x46]),
+      };
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      viewModel.proceedToReview();
+
+      await viewModel.downloadCombined();
+
+      expect(
+        fakeBatchDownloadRepo.downloadedUnitKeys,
+        contains('doc-1:unit-1'),
+      );
+    });
+
+    test('downloadCombined sets error status on download failure', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+      viewModel.proceedToReview();
+
+      fakeBatchDownloadRepo.errorToThrow = Exception('download failed');
+      final result = await viewModel.downloadCombined();
+
+      expect(result, isNull);
+      expect(viewModel.status, BatchDownloadStatus.error);
+      expect(viewModel.errorMessage, isNotNull);
+    });
+
+    test('combinedFileName uses first unit of first group', () async {
+      await navigateToStep2();
+      viewModel.toggleUnitSelection('doc-1', 'unit-1');
+      viewModel.addToCombination();
+
+      expect(viewModel.combinedFileName, contains('ALICE_SILVA'));
+      expect(viewModel.combinedFileName, endsWith('.PDF'));
+    });
+  });
 }

--- a/client/rufino_v2/test/widget/features/batch_download/batch_download_screen_test.dart
+++ b/client/rufino_v2/test/widget/features/batch_download/batch_download_screen_test.dart
@@ -155,4 +155,94 @@ void main() {
       expect(find.text('Status'), findsOneWidget);
     });
   });
+
+  group('Combination flow', () {
+    final testUnits = [
+      const BatchDownloadUnit(
+        documentUnitId: 'unit-1',
+        documentId: 'doc-1',
+        employeeId: 'emp-1',
+        employeeName: 'Alice Silva',
+        documentTemplateName: 'Holerite',
+        documentGroupName: 'RH',
+        date: '28/02/2026',
+        statusId: 2,
+        statusName: 'OK',
+        hasFile: true,
+      ),
+      const BatchDownloadUnit(
+        documentUnitId: 'unit-2',
+        documentId: 'doc-2',
+        employeeId: 'emp-2',
+        employeeName: 'Bob Santos',
+        documentTemplateName: 'Holerite',
+        documentGroupName: 'RH',
+        date: '28/02/2026',
+        statusId: 2,
+        statusName: 'OK',
+        hasFile: true,
+      ),
+    ];
+
+    Future<void> navigateToStep2(WidgetTester tester) async {
+      fakeBatchDownloadRepo.unitsPage = BatchDownloadUnitsPage(
+        items: testUnits,
+        totalCount: testUnits.length,
+      );
+
+      setupLargeScreen(tester);
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Select all employees
+      await tester.tap(find.text('Selecionar Todos'));
+      await tester.pumpAndSettle();
+
+      // Navigate to step 2
+      await tester.tap(find.text('Proximo'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('shows Adicionar a combinacao button on step 2',
+        (tester) async {
+      await navigateToStep2(tester);
+
+      expect(find.text('Adicionar a combinacao'), findsOneWidget);
+    });
+
+    testWidgets('combination indicator shows group count after adding',
+        (tester) async {
+      await navigateToStep2(tester);
+
+      // Select a unit
+      await tester.tap(find.text('Alice Silva - Holerite'));
+      await tester.pumpAndSettle();
+
+      // Add to combination
+      await tester.tap(find.text('Adicionar a combinacao'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('1 grupo(s)'), findsOneWidget);
+      expect(find.textContaining('1 documento(s)'), findsOneWidget);
+    });
+
+    testWidgets('combine review step renders when in combine mode',
+        (tester) async {
+      await navigateToStep2(tester);
+
+      // Select a unit and add to combination
+      await tester.tap(find.text('Alice Silva - Holerite'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Adicionar a combinacao'));
+      await tester.pumpAndSettle();
+
+      // Proceed to review
+      await tester.tap(find.text('Proximo'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Combinar e Baixar'), findsOneWidget);
+      expect(find.textContaining('grupo(s)'), findsWidgets);
+      expect(find.text('Grupo 1'), findsOneWidget);
+    });
+  });
 }

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDocumentController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDocumentController.cs
@@ -177,17 +177,17 @@ namespace PeopleManagement.API.Controllers
                 foreach (var item in result.Results)
                 {
                     var idSuffix = item.DocumentUnitId.ToString()[^4..];
-                    var employeeSlug = item.EmployeeName.Trim().Replace(" ", "-").ToLowerInvariant();
-                    var entry = archive.CreateEntry(
-                        $"{employeeSlug}-{item.DocumentUnitDate:yyyy-MM-dd}-{item.DocumentName}-{idSuffix}.pdf",
-                        CompressionLevel.Fastest);
+                    var employeeSegment = item.EmployeeName.Trim().Replace(" ", "_");
+                    var documentSegment = item.DocumentName.Trim().Replace(" ", "_");
+                    var entryName = $"{item.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+                    var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
                     using var entryStream = entry.Open();
                     await entryStream.WriteAsync(item.Pdf);
                 }
             }
 
             memoryStream.Position = 0;
-            return File(memoryStream, "application/octet-stream", "documents.zip");
+            return File(memoryStream, "application/octet-stream", "documents.zip".ToUpper());
         }
 
         [HttpPost("generate-range/send2sign")]

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDownloadController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDownloadController.cs
@@ -39,7 +39,7 @@ namespace PeopleManagement.API.Controllers
             [FromBody] BatchDownloadRequest request)
         {
             var stream = await _batchDownloadQueries.DownloadBatchDocumentUnits(company, request.Items);
-            return File(stream, "application/octet-stream", "documents.zip");
+            return File(stream, "application/octet-stream", "documents.zip".ToUpper());
         }
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentController.cs
@@ -68,7 +68,11 @@ namespace PeopleManagement.API.Controllers
 
             CommandResultLog(result, request.DocumentUnitId, request, requestId);
 
-            return File(result.Pdf, "application/pdf", $"doc_{result.Id.ToString().Substring(0,10)}.pdf");
+            var employeeSegment = result.EmployeeName.Trim().Replace(" ", "_");
+            var documentSegment = result.DocumentName.Trim().Replace(" ", "_");
+            var idSuffix = result.Id.ToString()[^4..];
+            var fileName = $"{result.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+            return File(result.Pdf, "application/pdf", fileName);
         }
 
         [HttpPost("generate/range/{employeeId}")]
@@ -84,19 +88,22 @@ namespace PeopleManagement.API.Controllers
             CommandResultLog(result, employeeId, request, Guid.Empty);
 
             var memoryStream = new MemoryStream();
+            var employeeSegment = result.EmployeeName.Trim().Replace(" ", "_");
             using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
             {
                 foreach (var item in result.Results)
                 {
                     var idSuffix = item.DocumentUnitId.ToString()[^4..];
-                    var entry = archive.CreateEntry($"{item.DocumentUnitDate:yyyy-MM-dd}-{item.DocumentName}-{idSuffix}.pdf", CompressionLevel.Fastest);
+                    var documentSegment = item.DocumentName.Trim().Replace(" ", "_");
+                    var entryName = $"{item.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+                    var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
                     using var entryStream = entry.Open();
                     await entryStream.WriteAsync(item.Pdf);
                 }
             }
 
             memoryStream.Position = 0;
-            return File(memoryStream, "application/octet-stream", "documents.zip");
+            return File(memoryStream, "application/octet-stream", "documents.zip".ToUpper());
         }
 
         [HttpPost("generate/send2sign")]
@@ -191,8 +198,12 @@ namespace PeopleManagement.API.Controllers
         public async Task<IActionResult> DownloadFile([FromRoute] Guid documentUnitId, [FromRoute] Guid documentId, [FromRoute] Guid employeeId,
             [FromRoute] Guid company)
         {
-            var stream = await _documentQueries.DownloadDocumentUnit(documentUnitId, documentId, employeeId, company);
-            return File(stream, "application/octet-stream", $"{documentUnitId}.zip");
+            var result = await _documentQueries.DownloadDocumentUnit(documentUnitId, documentId, employeeId, company);
+            var employeeSegment = result.EmployeeName.Trim().Replace(" ", "_");
+            var documentSegment = result.DocumentName.Trim().Replace(" ", "_");
+            var idSuffix = documentUnitId.ToString()[^4..];
+            var fileName = $"{result.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{result.Extension}".ToUpper();
+            return File(result.Stream, "application/octet-stream", fileName);
         }
 
         [HttpPost("download/range/{employeeId}")]
@@ -200,7 +211,7 @@ namespace PeopleManagement.API.Controllers
         public async Task<IActionResult> DownloadRange([FromRoute] Guid company, [FromRoute] Guid employeeId, [FromBody] List<DownloadRangeDocumentItem> request)
         {
             var stream = await _documentQueries.DownloadDocumentUnitRange(request, employeeId, company);
-            return File(stream, "application/octet-stream", "documents.zip");
+            return File(stream, "application/octet-stream", "documents.zip".ToUpper());
         }
 
         [HttpPut("DocumentUnit/invalid")]

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentTemplateController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentTemplateController.cs
@@ -119,7 +119,7 @@ namespace PeopleManagement.API.Controllers
         {
             var stream = await documentTemplateQueries.DownloadFile(documentTemplateId, company);
             stream.Position = 0;
-            return File(stream, "application/octet-stream", $"{documentTemplateId}.zip");
+            return File(stream, "application/octet-stream", $"{documentTemplateId}.zip".ToUpper());
         }
 
         [HttpGet("Events")]

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/EmployeeController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/EmployeeController.cs
@@ -554,7 +554,7 @@ namespace PeopleManagement.API.Controllers
             [FromRoute] Guid company)
         {
             var img = await employeeQueries.DownloadImage(employeeId, company);
-            return File(img.stream, "application/octet-stream", $"img-{employeeId}.{img.Extension}");
+            return File(img.stream, "application/octet-stream", $"img-{employeeId}.{img.Extension}".ToUpper());
         }
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdf/GeneratePdfCommandHandler.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdf/GeneratePdfCommandHandler.cs
@@ -1,25 +1,50 @@
-﻿
+
+using Microsoft.EntityFrameworkCore;
 using PeopleManagement.Application.Commands.Identified;
+using PeopleManagement.Domain.AggregatesModel.DocumentAggregate;
 using PeopleManagement.Domain.AggregatesModel.DocumentAggregate.Interfaces;
+using PeopleManagement.Domain.AggregatesModel.EmployeeAggregate;
+using PeopleManagement.Domain.AggregatesModel.EmployeeAggregate.Interfaces;
+using PeopleManagement.Domain.ErrorTools;
+using PeopleManagement.Domain.ErrorTools.ErrorsMessages;
 using PeopleManagement.Infra.Idempotency;
 
 namespace PeopleManagement.Application.Commands.DocumentCommands.GeneratePdf
 {
-    public class GeneratePdfCommandHandler(IDocumentService documentService) : IRequestHandler<GeneratePdfCommand, GeneratePdfResponse>
+    public class GeneratePdfCommandHandler(
+        IDocumentService documentService,
+        IDocumentRepository documentRepository,
+        IEmployeeRepository employeeRepository) : IRequestHandler<GeneratePdfCommand, GeneratePdfResponse>
     {
         private readonly IDocumentService _documentService = documentService;
+        private readonly IDocumentRepository _documentRepository = documentRepository;
+        private readonly IEmployeeRepository _employeeRepository = employeeRepository;
 
         public async Task<GeneratePdfResponse> Handle(GeneratePdfCommand request, CancellationToken cancellationToken)
         {
             var pdf = await _documentService.GeneratePdf(request.DocumentUnitId, request.DocumentId, request.EmployeeId, request.CompanyId, cancellationToken);
-            return new GeneratePdfResponse(request.DocumentUnitId, pdf);
+
+            var document = await _documentRepository.FirstOrDefaultAsync(
+                x => x.Id == request.DocumentId && x.EmployeeId == request.EmployeeId && x.CompanyId == request.CompanyId,
+                include: x => x.Include(y => y.DocumentsUnits),
+                cancellation: cancellationToken)
+                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(Document), request.DocumentId.ToString()));
+
+            var employee = await _employeeRepository.FirstOrDefaultAsync(
+                e => e.Id == request.EmployeeId && e.CompanyId == request.CompanyId,
+                cancellation: cancellationToken)
+                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(Employee), request.EmployeeId.ToString()));
+
+            var unit = document.DocumentsUnits.First(x => x.Id == request.DocumentUnitId);
+
+            return new GeneratePdfResponse(request.DocumentUnitId, pdf, employee.Name.Value, document.Name.ToString(), unit.Date);
         }
     }
-    public class CreateDocumentIdentifiedCommandHandler(IMediator mediator, 
-        ILogger<IdentifiedCommandHandler<GeneratePdfCommand, GeneratePdfResponse>> logger, IRequestManager requestManager) 
+    public class CreateDocumentIdentifiedCommandHandler(IMediator mediator,
+        ILogger<IdentifiedCommandHandler<GeneratePdfCommand, GeneratePdfResponse>> logger, IRequestManager requestManager)
         : IdentifiedCommandHandler<GeneratePdfCommand, GeneratePdfResponse>(mediator, logger, requestManager)
     {
-        protected override GeneratePdfResponse CreateResultForDuplicateRequest() => new(Guid.Empty, []);
+        protected override GeneratePdfResponse CreateResultForDuplicateRequest() => new(Guid.Empty, [], string.Empty, string.Empty, default);
 
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdf/GeneratePdfResponse.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdf/GeneratePdfResponse.cs
@@ -1,9 +1,14 @@
-﻿using PeopleManagement.Application.Commands.DocumentCommands.CreateDocument;
+using PeopleManagement.Application.Commands.DocumentCommands.CreateDocument;
 
 namespace PeopleManagement.Application.Commands.DocumentCommands.GeneratePdf
 {
-    public record GeneratePdfResponse(Guid Id, byte[] Pdf) : BaseDTO(Id)
+    public record GeneratePdfResponse(
+        Guid Id,
+        byte[] Pdf,
+        string EmployeeName,
+        string DocumentName,
+        DateOnly DocumentUnitDate) : BaseDTO(Id)
     {
-        public static implicit operator GeneratePdfResponse(Guid id) => new(id);
+        public static implicit operator GeneratePdfResponse(Guid id) => new(id, [], string.Empty, string.Empty, default);
     }
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdfRange/GeneratePdfRangeCommandHandler.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdfRange/GeneratePdfRangeCommandHandler.cs
@@ -1,14 +1,26 @@
 using PeopleManagement.Domain.AggregatesModel.DocumentAggregate.Interfaces;
+using PeopleManagement.Domain.AggregatesModel.EmployeeAggregate;
+using PeopleManagement.Domain.AggregatesModel.EmployeeAggregate.Interfaces;
+using PeopleManagement.Domain.ErrorTools;
+using PeopleManagement.Domain.ErrorTools.ErrorsMessages;
 
 namespace PeopleManagement.Application.Commands.DocumentCommands.GeneratePdfRange
 {
-    public class GeneratePdfRangeCommandHandler(IDocumentService documentService)
+    public class GeneratePdfRangeCommandHandler(
+        IDocumentService documentService,
+        IEmployeeRepository employeeRepository)
         : IRequestHandler<GeneratePdfRangeCommand, GeneratePdfRangeResponse>
     {
         private readonly IDocumentService _documentService = documentService;
+        private readonly IEmployeeRepository _employeeRepository = employeeRepository;
 
         public async Task<GeneratePdfRangeResponse> Handle(GeneratePdfRangeCommand request, CancellationToken cancellationToken)
         {
+            var employee = await _employeeRepository.FirstOrDefaultAsync(
+                e => e.Id == request.EmployeeId && e.CompanyId == request.CompanyId,
+                cancellation: cancellationToken)
+                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(Employee), request.EmployeeId.ToString()));
+
             var results = await _documentService.GeneratePdfRange(
                 request.Items.Select(x => (x.DocumentId, x.DocumentUnitIds)),
                 request.EmployeeId,
@@ -16,6 +28,7 @@ namespace PeopleManagement.Application.Commands.DocumentCommands.GeneratePdfRang
                 cancellationToken);
 
             return new GeneratePdfRangeResponse(
+                employee.Name.Value,
                 results.Select(r => new GeneratePdfRangeResponseItem(r.DocumentUnitId, r.DocumentId, r.DocumentName, r.DocumentUnitDate, r.Pdf)).ToList());
         }
     }

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdfRange/GeneratePdfRangeResponse.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Commands/DocumentCommands/GeneratePdfRange/GeneratePdfRangeResponse.cs
@@ -2,5 +2,5 @@ namespace PeopleManagement.Application.Commands.DocumentCommands.GeneratePdfRang
 {
     public record GeneratePdfRangeResponseItem(Guid DocumentUnitId, Guid DocumentId, string DocumentName, DateOnly DocumentUnitDate, byte[] Pdf);
 
-    public record GeneratePdfRangeResponse(IReadOnlyList<GeneratePdfRangeResponseItem> Results);
+    public record GeneratePdfRangeResponse(string EmployeeName, IReadOnlyList<GeneratePdfRangeResponseItem> Results);
 }

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Queries/BatchDownload/BatchDownloadQueries.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Queries/BatchDownload/BatchDownloadQueries.cs
@@ -210,11 +210,11 @@ namespace PeopleManagement.Application.Queries.BatchDownload
                         .Select(unit =>
                         {
                             var idSuffix = unit.Id.ToString()[^4..];
-                            var employeeSlug = employees.GetValueOrDefault(doc.EmployeeId, "unknown").Trim().Replace(" ", "-").ToLowerInvariant();
-                            var docName = templates.GetValueOrDefault(doc.DocumentTemplateId, "document");
+                            var employeeSegment = employees.GetValueOrDefault(doc.EmployeeId, "unknown").Trim().Replace(" ", "_");
+                            var documentSegment = templates.GetValueOrDefault(doc.DocumentTemplateId, "document").Trim().Replace(" ", "_");
                             return new
                             {
-                                EntryName = $"{employeeSlug}-{unit.Date:yyyy-MM-dd}-{docName}-{idSuffix}.{unit.Extension}",
+                                EntryName = $"{unit.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
                                 Task = _blobService.DownloadAsync(unit.GetNameWithExtension, companyId.ToString())
                             };
                         }))

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/DocumentQueries.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/DocumentQueries.cs
@@ -101,7 +101,7 @@ namespace PeopleManagement.Application.Queries.Document
             };
         }
 
-        public async Task<Stream> DownloadDocumentUnit(Guid documentUnitId, Guid documentId, Guid employeeId, Guid companyId)
+        public async Task<(Stream Stream, string EmployeeName, string DocumentName, DateOnly Date, string Extension)> DownloadDocumentUnit(Guid documentUnitId, Guid documentId, Guid employeeId, Guid companyId)
         {
             var document = await _context.Documents.AsNoTracking().Include(x => x.DocumentsUnits.Where(x => x.Id == documentUnitId))
                 .Where(x => x.EmployeeId == employeeId && x.CompanyId == companyId && x.Id == documentId).SingleOrDefaultAsync()
@@ -110,9 +110,14 @@ namespace PeopleManagement.Application.Queries.Document
             var documentUnit = document.DocumentsUnits.SingleOrDefault(x => x.Id == documentUnitId)
                 ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(DocumentUnit), documentUnitId.ToString()));
 
+            var employeeName = await _context.Employees.AsNoTracking()
+                .Where(e => e.Id == employeeId && e.CompanyId == companyId)
+                .Select(e => e.Name.Value)
+                .FirstOrDefaultAsync() ?? "unknown";
+
             var file = await _blobService.DownloadAsync(documentUnit.GetNameWithExtension, document.CompanyId.ToString());
 
-            return file;
+            return (file, employeeName, document.Name.ToString(), documentUnit.Date, documentUnit.Extension?.ToString() ?? string.Empty);
         }
 
         public async Task<Stream> DownloadDocumentUnitRange(IEnumerable<DownloadRangeDocumentItem> items, Guid employeeId, Guid companyId)
@@ -126,15 +131,26 @@ namespace PeopleManagement.Application.Queries.Document
                 .Where(x => documentIds.Contains(x.Id) && x.EmployeeId == employeeId && x.CompanyId == companyId)
                 .ToListAsync();
 
+            var employeeName = await _context.Employees.AsNoTracking()
+                .Where(e => e.Id == employeeId && e.CompanyId == companyId)
+                .Select(e => e.Name.Value)
+                .FirstOrDefaultAsync() ?? "unknown";
+            var employeeSegment = employeeName.Trim().Replace(" ", "_");
+
             var downloadTasks = documents
                 .Where(doc => unitIdsByDocument.TryGetValue(doc.Id, out _))
                 .SelectMany(doc =>
                     doc.DocumentsUnits
                         .Where(unit => unitIdsByDocument[doc.Id].Contains(unit.Id))
-                        .Select(unit => new
+                        .Select(unit =>
                         {
-                            EntryName = $"{unit.Date:yyyy-MM-dd}-{doc.Name}-{unit.Id.ToString()[^4..]}.{unit.Extension}",
-                            Task = _blobService.DownloadAsync(unit.GetNameWithExtension, companyId.ToString())
+                            var idSuffix = unit.Id.ToString()[^4..];
+                            var documentSegment = doc.Name.ToString().Trim().Replace(" ", "_");
+                            return new
+                            {
+                                EntryName = $"{unit.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
+                                Task = _blobService.DownloadAsync(unit.GetNameWithExtension, companyId.ToString())
+                            };
                         }))
                 .ToList();
 

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/IDocumentQueries.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/IDocumentQueries.cs
@@ -7,7 +7,7 @@ namespace PeopleManagement.Application.Queries.Document
     {
         Task<IEnumerable<DocumentSimpleDto>> GetAllSimple(Guid employeeId, Guid companyId);
         Task<DocumentDto> GetById(Guid documentId, Guid employeeId, Guid companyId, DocumentUnitParams unitParams);
-        Task<Stream> DownloadDocumentUnit(Guid documentUnitId, Guid documentId, Guid employeeId, Guid companyId);
+        Task<(Stream Stream, string EmployeeName, string DocumentName, DateOnly Date, string Extension)> DownloadDocumentUnit(Guid documentUnitId, Guid documentId, Guid employeeId, Guid companyId);
         Task<Stream> DownloadDocumentUnitRange(IEnumerable<DownloadRangeDocumentItem> items, Guid employeeId, Guid companyId);
     }
 }


### PR DESCRIPTION
  Extends the batch download wizard with a 'Combine Files' mode where
  users can build multiple selection groups in step 2 and merge them
  into a single PDF per employee client-side. Uses the existing
  pdf_combiner infrastructure for lossless merging and follows the
  backend naming pattern ({YYYY_MM_DD}-{EMPLOYEE}-{DOCUMENT}-{idSuffix}.PDF).