### PR TITLE
Extends the batch download wizard with a Combine Files mode where

### DIFF
--- a/client/rufino_v2/lib/core/utils/combine_file_namer.dart
+++ b/client/rufino_v2/lib/core/utils/combine_file_namer.dart
@@ -21,5 +21,5 @@ String buildCombinedFileName(BatchDownloadUnit firstUnit) {
   final idSuffix =
       id.length >= 4 ? id.substring(id.length - 4).toUpperCase() : id.toUpperCase();
 
-  return '$formattedDate-$employeeSegment-$documentSegment-$idSuffix.PDF';
+  return '$employeeSegment-$formattedDate-$documentSegment-$idSuffix.PDF';
 }

--- a/client/rufino_v2/lib/domain/entities/employee_document.dart
+++ b/client/rufino_v2/lib/domain/entities/employee_document.dart
@@ -133,12 +133,12 @@ class DocumentUnit {
         _ => statusName.isNotEmpty ? statusName : statusId,
       };
 
-  /// Converts the [date] from `dd/MM/yyyy` to `yyyy-MM-dd` for file names.
+  /// Converts the [date] from `dd/MM/yyyy` to `yyyy_MM_dd` for file names.
   ///
-  /// Returns `"sem-data"` when the date is empty or has an unexpected format.
+  /// Returns `"SEM_DATA"` when the date is empty or has an unexpected format.
   String get dateForFileName {
-    if (date.isEmpty || date.length != 10) return 'sem-data';
-    return '${date.substring(6)}-${date.substring(3, 5)}-'
+    if (date.isEmpty || date.length != 10) return 'SEM_DATA';
+    return '${date.substring(6)}_${date.substring(3, 5)}_'
         '${date.substring(0, 2)}';
   }
 
@@ -167,13 +167,22 @@ class DocumentUnit {
     return null;
   }
 
-  /// Builds a download file name from this unit's date and the parent
-  /// [docName], e.g. `"2026-03-01-contrato-de-trabalho.pdf"`.
-  String downloadFileName(String docName, {String extension = 'pdf'}) {
-    final namePart = docName
-        .toLowerCase()
-        .replaceAll(RegExp(r'[^\w\s-]'), '')
-        .replaceAll(RegExp(r'\s+'), '-');
-    return '$dateForFileName-$namePart.$extension';
+  /// Builds a download file name following the backend naming convention.
+  ///
+  /// Pattern: `{EMPLOYEE}-{YYYY_MM_DD}-{DOCUMENT}-{idSuffix}.{EXT}`,
+  /// all segments UPPERCASED with spaces replaced by underscores.
+  String downloadFileName(
+    String docName, {
+    required String employeeName,
+    String extension = 'pdf',
+  }) {
+    final employeeSegment =
+        employeeName.trim().replaceAll(' ', '_').toUpperCase();
+    final documentSegment =
+        docName.trim().replaceAll(' ', '_').toUpperCase();
+    final idSuffix = id.length >= 4
+        ? id.substring(id.length - 4).toUpperCase()
+        : id.toUpperCase();
+    return '$employeeSegment-$dateForFileName-$documentSegment-$idSuffix.${extension.toUpperCase()}';
   }
 }

--- a/client/rufino_v2/lib/ui/features/employee/widgets/components/documents_section.dart
+++ b/client/rufino_v2/lib/ui/features/employee/widgets/components/documents_section.dart
@@ -273,7 +273,10 @@ class _DocumentsSectionState extends State<DocumentsSection> {
       if (bytes != null && mounted) {
         final saved = await _saveFile(
           dialogTitle: 'Salvar documento',
-          fileName: unit.downloadFileName(doc.name),
+          fileName: unit.downloadFileName(
+            doc.name,
+            employeeName: widget.viewModel.profile?.name ?? '',
+          ),
           bytes: bytes,
         );
         if (!saved && mounted) {
@@ -888,7 +891,10 @@ class _DocumentsSectionState extends State<DocumentsSection> {
       await showDialog<void>(
         context: context,
         builder: (ctx) => _PdfViewerDialog(
-          title: unit.downloadFileName(doc.name),
+          title: unit.downloadFileName(
+            doc.name,
+            employeeName: widget.viewModel.profile?.name ?? '',
+          ),
           bytes: bytes,
         ),
       );

--- a/client/rufino_v2/test/unit/core/utils/combine_file_namer_test.dart
+++ b/client/rufino_v2/test/unit/core/utils/combine_file_namer_test.dart
@@ -20,7 +20,7 @@ void main() {
 
       final result = buildCombinedFileName(unit);
 
-      expect(result, '2026_02_28-ALICE_SILVA-HOLERITE-1234.PDF');
+      expect(result, 'ALICE_SILVA-2026_02_28-HOLERITE-1234.PDF');
     });
 
     test('replaces spaces with underscores in multi-word names', () {
@@ -41,7 +41,7 @@ void main() {
 
       expect(
         result,
-        '2025_12_01-MARIA_APARECIDA_DOS_SANTOS-CONTRATO_DE_TRABALHO-5678.PDF',
+        'MARIA_APARECIDA_DOS_SANTOS-2025_12_01-CONTRATO_DE_TRABALHO-5678.PDF',
       );
     });
 
@@ -61,7 +61,7 @@ void main() {
 
       final result = buildCombinedFileName(unit);
 
-      expect(result, '2026_01_05-BOB-ASO-AB.PDF');
+      expect(result, 'BOB-2026_01_05-ASO-AB.PDF');
     });
 
     test('uppercases all segments including suffix', () {
@@ -80,7 +80,7 @@ void main() {
 
       final result = buildCombinedFileName(unit);
 
-      expect(result, '2026_06_15-JOAO-RECIBO-ABCD.PDF');
+      expect(result, 'JOAO-2026_06_15-RECIBO-ABCD.PDF');
     });
   });
 }

--- a/client/rufino_v2/test/unit/domain/entities/employee_document_test.dart
+++ b/client/rufino_v2/test/unit/domain/entities/employee_document_test.dart
@@ -213,7 +213,7 @@ void main() {
   });
 
   group('DocumentUnit.dateForFileName', () {
-    test('converts dd/MM/yyyy date to yyyy-MM-dd format', () {
+    test('converts dd/MM/yyyy date to yyyy_MM_dd format', () {
       const unit = DocumentUnit(
         id: '1',
         statusId: '1',
@@ -224,10 +224,10 @@ void main() {
         hasFile: false,
         name: '',
       );
-      expect(unit.dateForFileName, '2026-03-01');
+      expect(unit.dateForFileName, '2026_03_01');
     });
 
-    test('returns sem-data when date is empty', () {
+    test('returns SEM_DATA when date is empty', () {
       const unit = DocumentUnit(
         id: '1',
         statusId: '1',
@@ -238,14 +238,14 @@ void main() {
         hasFile: false,
         name: '',
       );
-      expect(unit.dateForFileName, 'sem-data');
+      expect(unit.dateForFileName, 'SEM_DATA');
     });
   });
 
   group('DocumentUnit.downloadFileName', () {
-    test('builds correct file name with slugified document name', () {
+    test('follows backend pattern with employee, date, document, suffix', () {
       const unit = DocumentUnit(
-        id: '1',
+        id: 'abc-unit-1234',
         statusId: '1',
         statusName: '',
         date: '01/03/2026',
@@ -255,14 +255,17 @@ void main() {
         name: '',
       );
       expect(
-        unit.downloadFileName('Contrato de Trabalho'),
-        '2026-03-01-contrato-de-trabalho.pdf',
+        unit.downloadFileName(
+          'Contrato de Trabalho',
+          employeeName: 'Alice Silva',
+        ),
+        'ALICE_SILVA-2026_03_01-CONTRATO_DE_TRABALHO-1234.PDF',
       );
     });
 
     test('uses custom extension when provided', () {
       const unit = DocumentUnit(
-        id: '1',
+        id: 'abc-unit-5678',
         statusId: '1',
         statusName: '',
         date: '15/06/2025',
@@ -272,8 +275,12 @@ void main() {
         name: '',
       );
       expect(
-        unit.downloadFileName('Holerite', extension: 'png'),
-        '2025-06-15-holerite.png',
+        unit.downloadFileName(
+          'Holerite',
+          employeeName: 'Bob Santos',
+          extension: 'png',
+        ),
+        'BOB_SANTOS-2025_06_15-HOLERITE-5678.PNG',
       );
     });
   });

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDocumentController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/BatchDocumentController.cs
@@ -179,7 +179,7 @@ namespace PeopleManagement.API.Controllers
                     var idSuffix = item.DocumentUnitId.ToString()[^4..];
                     var employeeSegment = item.EmployeeName.Trim().Replace(" ", "_");
                     var documentSegment = item.DocumentName.Trim().Replace(" ", "_");
-                    var entryName = $"{item.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+                    var entryName = $"{employeeSegment}-{item.DocumentUnitDate:yyyy_MM_dd}-{documentSegment}-{idSuffix}.pdf".ToUpper();
                     var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
                     using var entryStream = entry.Open();
                     await entryStream.WriteAsync(item.Pdf);

--- a/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentController.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.API/Controllers/DocumentController.cs
@@ -71,7 +71,7 @@ namespace PeopleManagement.API.Controllers
             var employeeSegment = result.EmployeeName.Trim().Replace(" ", "_");
             var documentSegment = result.DocumentName.Trim().Replace(" ", "_");
             var idSuffix = result.Id.ToString()[^4..];
-            var fileName = $"{result.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+            var fileName = $"{employeeSegment}-{result.DocumentUnitDate:yyyy_MM_dd}-{documentSegment}-{idSuffix}.pdf".ToUpper();
             return File(result.Pdf, "application/pdf", fileName);
         }
 
@@ -95,7 +95,7 @@ namespace PeopleManagement.API.Controllers
                 {
                     var idSuffix = item.DocumentUnitId.ToString()[^4..];
                     var documentSegment = item.DocumentName.Trim().Replace(" ", "_");
-                    var entryName = $"{item.DocumentUnitDate:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.pdf".ToUpper();
+                    var entryName = $"{employeeSegment}-{item.DocumentUnitDate:yyyy_MM_dd}-{documentSegment}-{idSuffix}.pdf".ToUpper();
                     var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
                     using var entryStream = entry.Open();
                     await entryStream.WriteAsync(item.Pdf);
@@ -202,7 +202,7 @@ namespace PeopleManagement.API.Controllers
             var employeeSegment = result.EmployeeName.Trim().Replace(" ", "_");
             var documentSegment = result.DocumentName.Trim().Replace(" ", "_");
             var idSuffix = documentUnitId.ToString()[^4..];
-            var fileName = $"{result.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{result.Extension}".ToUpper();
+            var fileName = $"{employeeSegment}-{result.Date:yyyy_MM_dd}-{documentSegment}-{idSuffix}.{result.Extension}".ToUpper();
             return File(result.Stream, "application/octet-stream", fileName);
         }
 

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Queries/BatchDownload/BatchDownloadQueries.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Queries/BatchDownload/BatchDownloadQueries.cs
@@ -214,7 +214,7 @@ namespace PeopleManagement.Application.Queries.BatchDownload
                             var documentSegment = templates.GetValueOrDefault(doc.DocumentTemplateId, "document").Trim().Replace(" ", "_");
                             return new
                             {
-                                EntryName = $"{unit.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
+                                EntryName = $"{employeeSegment}-{unit.Date:yyyy_MM_dd}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
                                 Task = _blobService.DownloadAsync(unit.GetNameWithExtension, companyId.ToString())
                             };
                         }))

--- a/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/DocumentQueries.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Application/Queries/Document/DocumentQueries.cs
@@ -148,7 +148,7 @@ namespace PeopleManagement.Application.Queries.Document
                             var documentSegment = doc.Name.ToString().Trim().Replace(" ", "_");
                             return new
                             {
-                                EntryName = $"{unit.Date:yyyy_MM_dd}-{employeeSegment}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
+                                EntryName = $"{employeeSegment}-{unit.Date:yyyy_MM_dd}-{documentSegment}-{idSuffix}.{unit.Extension}".ToUpper(),
                                 Task = _blobService.DownloadAsync(unit.GetNameWithExtension, companyId.ToString())
                             };
                         }))


### PR DESCRIPTION
  users build numbered selection groups and merge them into one PDF per
  employee client-side. Standardizes all document file names across
  download, generation, and combination to follow the backend pattern:
  {EMPLOYEE}-{YYYY_MM_DD}-{DOCUMENT}-{idSuffix}.{EXT}.