### PR TITLE
 refactor(document): simplifica UpdateDocumentUnitDetails e centraliz…

### DIFF
--- a/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/Document.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/Document.cs
@@ -100,6 +100,10 @@ namespace PeopleManagement.Domain.AggregatesModel.DocumentAggregate
 
             documentUnit.UpdateDetails(date, validity, content);
 
+            if (documentUnit.IsPeriod)
+                VerifyDuplicatedPendings(documentUnit);
+
+            RefreshDocumentStatus();
             return documentUnit;
         }
 
@@ -109,26 +113,24 @@ namespace PeopleManagement.Domain.AggregatesModel.DocumentAggregate
                 ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(DocumentUnit), documentUnitId.ToString()));
 
             documentUnit.UpdateDetails(date, validity, content);
+
+            if (documentUnit.IsPeriod)
+                VerifyDuplicatedPendings(documentUnit);
+
             RefreshDocumentStatus();
             return documentUnit;
         }
 
-        public DocumentUnit UpdateDocumentUnitDetails(Guid documentUnitId, DateOnly date, TimeSpan? validity, string content, PeriodType periodType)
+        private void VerifyDuplicatedPendings(DocumentUnit documentUnit)
         {
-            var documentUnit = DocumentsUnits.FirstOrDefault(x => x.Id == documentUnitId)
-                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(DocumentUnit), documentUnitId.ToString()));
-
-            documentUnit.UpdateDetails(date, validity, content, periodType);
-
             var duplicatePending = DocumentsUnits
-                .Where(x => x.Id != documentUnitId && x.Status == DocumentUnitStatus.Pending && x.Period != null && x.Period.Equals(documentUnit.Period))
+                .Where(x => x.Id != documentUnit.Id && x.Status == DocumentUnitStatus.Pending && x.Period != null && x.Period.Equals(documentUnit.Period))
                 .ToList();
 
             duplicatePending.ForEach(x => x.MaskAsInvalid());
-
-            RefreshDocumentStatus();
-            return documentUnit;
         }
+
+
 
         public DocumentUnit GetDocumentUnit(Guid documentUnitId)
         {

--- a/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/DocumentUnit.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Domain/AggregatesModel/DocumentAggregate/DocumentUnit.cs
@@ -95,6 +95,8 @@ namespace PeopleManagement.Domain.AggregatesModel.DocumentAggregate
             Date = date;
             Validity = validity;    
             Content = content;
+            if (IsPeriod)
+                SetPeriod(Period!.Type, date.ToDateTime(TimeOnly.MinValue));
         }
 
         public void UpdateDetails(DateOnly date, TimeSpan? validity, string content)
@@ -108,21 +110,11 @@ namespace PeopleManagement.Domain.AggregatesModel.DocumentAggregate
             }
             Validity = dateValidity;
             Content = content;
+            if(IsPeriod)
+                SetPeriod(Period!.Type, date.ToDateTime(TimeOnly.MinValue));
         }
 
-        public void UpdateDetails(DateOnly date, TimeSpan? validity, string content, PeriodType periodType)
-        {
-            Date = date;
-            DateOnly? dateValidity = null;
-            if (validity is not null && validity != TimeSpan.Zero)
-            {
-                var dateTimeValidity = date.ToDateTime(TimeOnly.MinValue).Add(validity.Value);
-                dateValidity = DateOnly.FromDateTime(dateTimeValidity);
-            }
-            Validity = dateValidity;
-            Content = content;
-            SetPeriod(periodType, date.ToDateTime(TimeOnly.MinValue));
-        }
+
 
         public void MaskAsInvalid()
         {
@@ -209,6 +201,7 @@ namespace PeopleManagement.Domain.AggregatesModel.DocumentAggregate
         public bool IsPeriodWeekly => Period?.IsWeekly ?? false;
         public bool IsPeriodMonthly => Period?.IsMonthly ?? false;
         public bool IsPeriodYearly => Period?.IsYearly ?? false;
+        public bool IsPeriod => Period != null; 
 
         private bool HasInvalidDateOrValidity => Date == DateOnly.MinValue || Date == DateOnly.MaxValue || (Validity != null && (Validity == DateOnly.MinValue || Validity == DateOnly.MaxValue));
 

--- a/server/Services/PeopleManagement/PeopleManagement.Services/Services/DocumentService.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.Services/Services/DocumentService.cs
@@ -283,27 +283,13 @@ namespace PeopleManagement.Services.Services
                 workloadEndDate = await VerifyTimeConflictBetweenDocument(employeeId, companyId, documentId, documentUnitDate,
                     (TimeSpan)documentTemplate.Workload, cancellationToken);
 
-            var requiredDocument = await _requireDocumentsRepository.FirstOrDefaultAsync(x => x.Id == document.RequiredDocumentId
-                && x.CompanyId == companyId, cancellation: cancellationToken)
-                ?? throw new DomainException(this, DomainErrors.ObjectNotFound(nameof(RequireDocuments), document.RequiredDocumentId.ToString()));
-
-            var recurringEventFrequency = RecurringEvents.GetUniqueRecurringEventsFrequency(requiredDocument.ListenEvents.Select(x => x.EventId));
-            var periodType = ConvertFrequencyToPeriodType(recurringEventFrequency);
             string? content = "";
 
             DocumentUnit documentUnit;
 
-            if(periodType != null)
-            {
-                documentUnit = document.UpdateDocumentUnitDetails(documentUnitId, documentUnitDate, documentTemplate.DocumentValidityDuration,
-                content, periodType);
-
-            }
-            else
-            {
-                documentUnit = document.UpdateDocumentUnitDetails(documentUnitId, documentUnitDate, documentTemplate.DocumentValidityDuration,
-                content);
-            }
+            documentUnit = document.UpdateDocumentUnitDetails(documentUnitId, documentUnitDate, documentTemplate.DocumentValidityDuration,
+            content);
+    
 
             if (workloadEndDate is not null)
                 documentUnit.SetWorkloadEndDate(workloadEndDate.Value);

--- a/server/Services/PeopleManagement/PeopleManagement.UnitTests/Aggregates/DocumentTests/DocumentTests.cs
+++ b/server/Services/PeopleManagement/PeopleManagement.UnitTests/Aggregates/DocumentTests/DocumentTests.cs
@@ -140,7 +140,7 @@ namespace PeopleManagement.UnitTests.Aggregates.DocumentTests
             Assert.Equal(2, document.DocumentsUnits.Count);
 
             // Atualiza o segundo para ter o mesmo period do primeiro
-            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(referenceDate), TimeSpan.Zero, "", PeriodType.Monthly);
+            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(referenceDate), TimeSpan.Zero, "");
 
             Assert.Equal(DocumentUnitStatus.Invalid, firstUnit.Status);
             Assert.Equal(DocumentUnitStatus.Pending, secondUnit.Status);
@@ -159,7 +159,7 @@ namespace PeopleManagement.UnitTests.Aggregates.DocumentTests
             var secondUnit = document.NewDocumentUnit(Guid.NewGuid(), PeriodType.Monthly, differentReferenceDate);
 
             // Atualiza o segundo para ter o mesmo period do primeiro (que já é OK)
-            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(referenceDate), TimeSpan.Zero, "", PeriodType.Monthly);
+            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(referenceDate), TimeSpan.Zero, "");
 
             Assert.NotEqual(DocumentUnitStatus.Invalid, firstUnit.Status);
         }
@@ -175,7 +175,7 @@ namespace PeopleManagement.UnitTests.Aggregates.DocumentTests
             var secondUnit = document.NewDocumentUnit(Guid.NewGuid(), PeriodType.Monthly, differentReferenceDate);
 
             // Atualiza o segundo mantendo um period diferente do primeiro
-            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(differentReferenceDate), TimeSpan.Zero, "", PeriodType.Monthly);
+            document.UpdateDocumentUnitDetails(secondUnit.Id, DateOnly.FromDateTime(differentReferenceDate), TimeSpan.Zero, "");
 
             Assert.Equal(DocumentUnitStatus.Pending, firstUnit.Status);
             Assert.Equal(DocumentUnitStatus.Pending, secondUnit.Status);


### PR DESCRIPTION
…a invalidacao de duplicadas

  - Remove a sobrecarga de UpdateDocumentUnitDetails que recebia PeriodType explicitamente (em Document e DocumentUnit). O tipo de periodo agora e reaproveitado do proprio DocumentUnit via Period.Type, ja que e definido na criacao e nao muda em updates.
  - Extrai a logica de invalidacao de DocumentUnits pendentes com mesmo Period para o helper privado VerifyDuplicatedPendings em Document, acionado por ambas as sobrecargas quando o unit possui periodo.
  - DocumentService.UpdateDocumentUnitDetails deixa de consultar RequireDocumentsRepository e de calcular PeriodType via ConvertFrequencyToPeriodType.
  - Adiciona a propriedade auxiliar DocumentUnit.IsPeriod.
  - Atualiza DocumentTests para a nova assinatura.