### PR TITLE
Force fresh assets on web deploy via nginx + SW auto-update

### DIFF
--- a/client/rufino_v2/Dockerfile
+++ b/client/rufino_v2/Dockerfile
@@ -28,15 +28,9 @@ FROM nginx:alpine
 
 COPY --from=build /app/build/web /usr/share/nginx/html
 
-# SPA fallback: redirect all routes to index.html
-RUN echo 'server { \
-    listen 80; \
-    root /usr/share/nginx/html; \
-    index index.html; \
-    location / { \
-        try_files $uri $uri/ /index.html; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+# Cache-Control headers + SPA fallback. Defined in nginx/default.conf so it
+# stays reviewable and matches the cache-busting plan for production deploys.
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/client/rufino_v2/nginx/default.conf
+++ b/client/rufino_v2/nginx/default.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Entry points and unhashed files: always revalidate so deploys take
+    # effect on the next navigation.
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+    location = /flutter_bootstrap.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+    location = /flutter_service_worker.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+    location = /manifest.json {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+    location = /version.json {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+    location ~* ^/main\.dart\.js(\.map)?$ {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
+    # Hashed/versioned assets: safe to cache for a year.
+    location ~* ^/(assets|canvaskit)/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+    location ~* \.(wasm|symbols|part\.js|part\.js\.map)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    # SPA fallback.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/client/rufino_v2/web/index.html
+++ b/client/rufino_v2/web/index.html
@@ -20,6 +20,12 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
 
+  <!-- Defense in depth: HTTP headers from nginx are the primary cache busting
+       mechanism, but some browsers also honour these meta tags. -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -39,5 +45,29 @@
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>
+  <script>
+    // Force the Flutter service worker to check for a new version on every
+    // page load and reload once the new worker finishes installing. Combined
+    // with the nginx no-cache headers on the entry points, this means a fresh
+    // deploy reaches users on the next navigation without manual cache clears.
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function () {
+        navigator.serviceWorker.getRegistrations().then(function (regs) {
+          regs.forEach(function (reg) {
+            reg.update();
+            reg.addEventListener('updatefound', function () {
+              var sw = reg.installing;
+              if (!sw) return;
+              sw.addEventListener('statechange', function () {
+                if (sw.state === 'installed' && navigator.serviceWorker.controller) {
+                  window.location.reload();
+                }
+              });
+            });
+          });
+        });
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Adds explicit Cache-Control headers to the nginx config used in the production image: no-cache for entry points (index.html, flutter_bootstrap.js, flutter_service_worker.js, manifest.json, version.json, main.dart.js[.map]) and immutable long-cache for hashed assets (/assets/, /canvaskit/, *.wasm, *.symbols, *.part.js[.map]).

Also wires a small bootstrap script in web/index.html that calls ServiceWorkerRegistration.update() on load and reloads the page when a new worker finishes installing. Together this makes a redeploy reach users on the next navigation without manual cache clears.