### PR TITLE
Pass Auth Code Flow secrets to the production Docker build

### DIFF
--- a/client/rufino_v2/Dockerfile
+++ b/client/rufino_v2/Dockerfile
@@ -10,15 +10,18 @@ RUN flutter pub get
 # Copy the rest of the source code
 COPY . .
 
-# Generate secrets/prod_config.json from build args
-ARG AUTHORIZATION_ENDPOINT
+# Generate secrets/prod_config.json from build args. The app defaults to the
+# Authorization Code Flow + PKCE, so only the auth-code endpoints are required;
+# Direct Access Grants secrets (authorization_endpoint, secret) are no longer
+# part of the production build.
+ARG AUTH_CODE_AUTHORIZATION_ENDPOINT
+ARG AUTH_CODE_TOKEN_ENDPOINT
 ARG END_SESSION_ENDPOINT
 ARG IDENTIFIER
-ARG SECRET
 ARG PEOPLE_MANAGEMENT_URL
 
 RUN mkdir -p secrets && \
-    echo "{\"authorization_endpoint\":\"$AUTHORIZATION_ENDPOINT\",\"end_session_endpoint\":\"$END_SESSION_ENDPOINT\",\"identifier\":\"$IDENTIFIER\",\"secret\":\"$SECRET\",\"people_management_url\":\"$PEOPLE_MANAGEMENT_URL\"}" \
+    echo "{\"auth_code_authorization_endpoint\":\"$AUTH_CODE_AUTHORIZATION_ENDPOINT\",\"auth_code_token_endpoint\":\"$AUTH_CODE_TOKEN_ENDPOINT\",\"end_session_endpoint\":\"$END_SESSION_ENDPOINT\",\"identifier\":\"$IDENTIFIER\",\"people_management_url\":\"$PEOPLE_MANAGEMENT_URL\"}" \
     > secrets/prod_config.json
 
 RUN flutter build web --release --dart-define-from-file=secrets/prod_config.json


### PR DESCRIPTION
The Dockerfile was still injecting the Direct Access Grants pair (`authorization_endpoint` + `secret`), but `assertConfigured()` now requires `auth_code_authorization_endpoint` and
`auth_code_token_endpoint` by default. Production builds were therefore failing at boot inside `main()` with a missing-secrets StateError.

Switches the build args to the Auth Code endpoints and drops the unused DAG variables. Pipelines building the image must update their `--build-arg` invocations accordingly:
AUTHORIZATION_ENDPOINT/SECRET → AUTH_CODE_AUTHORIZATION_ENDPOINT + AUTH_CODE_TOKEN_ENDPOINT.