### PR TITLE
Add iOS Podfile enabling permission_handler camera macro

### DIFF
--- a/client/rufino_v2/ios/Podfile
+++ b/client/rufino_v2/ios/Podfile
@@ -1,0 +1,52 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '15.5'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      # Enable permission_handler permissions actually used by the app.
+      # Without these macros, the matching Permission.* code paths are
+      # compiled out and requests resolve to denied without a prompt.
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+      ]
+    end
+  end
+end

--- a/client/rufino_v2/pubspec.yaml
+++ b/client/rufino_v2/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rufino_v2
 description: "Rufino — gestão de pessoas"
 publish_to: 'none'
-version: 2.0.0+2
+version: 2.0.0+3
 
 environment:
   sdk: ^3.5.2


### PR DESCRIPTION
The document scanner request never reached the OS on iOS: NSCameraUsageDescription was set and Permission.camera.request() was being called, but without a custom Podfile the permission_handler plugin compiled with no PERMISSION_* macros, so the camera code path was stripped at build time. The system never registered a request, the prompt never appeared, and Camera was absent from Settings -> Rufino -- making the "Open Settings" dialog from 1aab0c34 useless.

- Add ios/Podfile with the standard Flutter template and a post_install hook that injects PERMISSION_CAMERA=1 into GCC_PREPROCESSOR_DEFINITIONS for every pod target.
- Bump iOS build to 2.0.0+3 so the new binary supersedes the previous App Store upload.