### PR TITLE
Use JPEG for iOS document scanner output

### DIFF
--- a/client/rufino_v2/lib/core/utils/document_scanner_service_mobile.dart
+++ b/client/rufino_v2/lib/core/utils/document_scanner_service_mobile.dart
@@ -32,6 +32,14 @@ class DocumentScannerServiceImpl implements DocumentScannerService {
     try {
       imagePaths = await CunningDocumentScanner.getPictures(
         isGalleryImportAllowed: true,
+        // PNG (plugin default on iOS) is encoded synchronously on the main
+        // thread via libpng+zlib, which hangs the UI for ~150–300 ms per page
+        // at VisionKit's native resolution. JPEG is 5–10× faster and Android
+        // already hard-codes JPEG, so this also aligns the two platforms.
+        iosScannerOptions: const IosScannerOptions(
+          imageFormat: IosImageFormat.jpg,
+          jpgCompressionQuality: 0.8,
+        ),
       );
     } on DocumentScannerException {
       rethrow;


### PR DESCRIPTION
The plugin default of PNG encodes each page synchronously on the main thread via libpng+zlib, hanging the UI for ~150-300 ms per page at VisionKit's native resolution. Switching to JPEG (quality 0.8) cuts per-page encoding 5-10x and aligns iOS with the Android backend, which already uses JPEG.