### PR TITLE
Downscale and re-encode scanned pages to fit 10 MB upload cap

### DIFF
--- a/client/rufino_v2/lib/core/utils/image_to_pdf_converter.dart
+++ b/client/rufino_v2/lib/core/utils/image_to_pdf_converter.dart
@@ -25,17 +25,38 @@ const kSupportedImageExtensions = [
 /// All file extensions allowed in the document upload picker.
 const kAllowedUploadExtensions = ['pdf', ...kSupportedImageExtensions];
 
+/// Maximum length (in pixels) of the longest side of an image embedded in
+/// the generated PDF.
+///
+/// Document scanners (especially Apple VisionKit) can produce pages above
+/// 3000 px on the long side. Anything beyond ~2000 px adds file size with
+/// no readability gain on printed documents, so pages above this threshold
+/// are downscaled before being embedded.
+const kPdfPageMaxLongSide = 2000;
+
+/// JPEG quality used when re-encoding image pages for the generated PDF.
+///
+/// 75 is the standard sweet spot for document scans: visually
+/// indistinguishable from the original at viewing distance, while shrinking
+/// each page to roughly 200–400 KB. Keeps a 17-page scan well under the
+/// backend's 10 MB upload limit.
+const kPdfPageJpegQuality = 75;
+
 /// Whether [extension] (without dot, case-insensitive) is a supported image.
 bool isImageExtension(String extension) =>
     kSupportedImageExtensions.contains(extension.toLowerCase());
 
 /// Converts a list of raw image bytes into a single multi-page PDF.
 ///
-/// Each entry in [imageBytesList] becomes one page whose dimensions match
-/// the source image. Images that cannot be decoded are silently skipped.
+/// Each entry in [imageBytesList] becomes one page. Pages whose longest
+/// side exceeds [kPdfPageMaxLongSide] are downscaled, and every page is
+/// re-encoded as JPEG at [kPdfPageJpegQuality] before being embedded — this
+/// keeps the output under the backend's 10 MB upload cap even for long
+/// scans. Images that cannot be decoded are silently skipped.
 ///
-/// All heavy work (image decoding, PDF building, and serialization) runs
-/// in a background isolate via [compute] so the UI thread stays responsive.
+/// All heavy work (image decoding, resizing, JPEG encoding, PDF building,
+/// and serialization) runs in a background isolate via [compute] so the UI
+/// thread stays responsive.
 Future<Uint8List> convertImagesToPdf(List<Uint8List> imageBytesList) {
   return compute(_buildPdfFromImages, imageBytesList);
 }
@@ -55,14 +76,19 @@ Future<Uint8List> _buildPdfFromImages(List<Uint8List> imageBytesList) async {
     }
     if (decoded == null) continue;
 
+    final normalized = _normalizeForPdf(decoded);
+    final encoded = Uint8List.fromList(
+      img.encodeJpg(normalized, quality: kPdfPageJpegQuality),
+    );
+
     document.addPage(
       pw.Page(
         pageFormat: PdfPageFormat(
-          decoded.width.toDouble(),
-          decoded.height.toDouble(),
+          normalized.width.toDouble(),
+          normalized.height.toDouble(),
         ),
         build: (context) => pw.Center(
-          child: pw.Image(pw.MemoryImage(pageBytes)),
+          child: pw.Image(pw.MemoryImage(encoded)),
         ),
       ),
     );
@@ -70,4 +96,16 @@ Future<Uint8List> _buildPdfFromImages(List<Uint8List> imageBytesList) async {
 
   final bytes = await document.save();
   return Uint8List.fromList(bytes);
+}
+
+/// Returns [image] scaled down so its longest side is at most
+/// [kPdfPageMaxLongSide]; returns the original when already within limits.
+img.Image _normalizeForPdf(img.Image image) {
+  final longSide = image.width >= image.height ? image.width : image.height;
+  if (longSide <= kPdfPageMaxLongSide) return image;
+
+  if (image.width >= image.height) {
+    return img.copyResize(image, width: kPdfPageMaxLongSide);
+  }
+  return img.copyResize(image, height: kPdfPageMaxLongSide);
 }

--- a/client/rufino_v2/test/unit/core/utils/image_to_pdf_converter_test.dart
+++ b/client/rufino_v2/test/unit/core/utils/image_to_pdf_converter_test.dart
@@ -71,6 +71,68 @@ void main() {
       expect(doc.pages.count, equals(0));
       doc.dispose();
     });
+
+    test('downscales pages whose longest side exceeds the PDF cap', () async {
+      final oversizedLandscape = _createTestImage(
+        width: kPdfPageMaxLongSide * 2,
+        height: kPdfPageMaxLongSide,
+      );
+
+      final pdfBytes = await convertImagesToPdf([oversizedLandscape]);
+
+      final doc = PdfDocument(inputBytes: pdfBytes);
+      expect(doc.pages.count, equals(1));
+      final pageSize = doc.pages[0].size;
+      expect(pageSize.width.round(), equals(kPdfPageMaxLongSide));
+      expect(pageSize.height.round(), equals(kPdfPageMaxLongSide ~/ 2));
+      doc.dispose();
+    });
+
+    test('downscales portrait pages by capping the height', () async {
+      final oversizedPortrait = _createTestImage(
+        width: kPdfPageMaxLongSide,
+        height: kPdfPageMaxLongSide * 2,
+      );
+
+      final pdfBytes = await convertImagesToPdf([oversizedPortrait]);
+
+      final doc = PdfDocument(inputBytes: pdfBytes);
+      final pageSize = doc.pages[0].size;
+      expect(pageSize.height.round(), equals(kPdfPageMaxLongSide));
+      expect(pageSize.width.round(), equals(kPdfPageMaxLongSide ~/ 2));
+      doc.dispose();
+    });
+
+    test('keeps dimensions when image is already within the PDF cap',
+        () async {
+      final small = _createTestImage(width: 800, height: 600);
+
+      final pdfBytes = await convertImagesToPdf([small]);
+
+      final doc = PdfDocument(inputBytes: pdfBytes);
+      final pageSize = doc.pages[0].size;
+      expect(pageSize.width.round(), equals(800));
+      expect(pageSize.height.round(), equals(600));
+      doc.dispose();
+    });
+
+    test(
+      'output stays under the 10 MB upload cap for many oversized pages',
+      () async {
+        // Simulates a long scan (17 pages at VisionKit-sized PNGs) — the
+        // exact scenario that previously blew past the backend's 10 MB cap.
+        final page = _createTestImage(
+          width: kPdfPageMaxLongSide * 2,
+          height: kPdfPageMaxLongSide * 2,
+        );
+        final pages = List<Uint8List>.generate(17, (_) => page);
+
+        final pdfBytes = await convertImagesToPdf(pages);
+
+        expect(pdfBytes.lengthInBytes, lessThan(10 * 1024 * 1024));
+      },
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
   });
 
   group('isImageExtension', () {


### PR DESCRIPTION
iOS document scanner emits very large JPEGs (often 3000+ px on the long side); embedding them as-is pushed a 17-page scan well past the backend's 10 MB upload limit. convertImagesToPdf now caps each page at 2000 px on the long side and re-encodes to JPEG quality 75 inside the isolate, which keeps long scans well under the limit while staying visually indistinguishable at viewing distance.