### PR TITLE
fix(ios): adiciona purpose string de localização exigida pelo ML Kit

### DIFF
--- a/client/rufino_v2/ios/Runner/Info.plist
+++ b/client/rufino_v2/ios/Runner/Info.plist
@@ -51,6 +51,8 @@
 	<string>O Rufino usa o microfone apenas durante a captura de vídeo na digitalização de documentos.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>O Rufino usa o Face ID para proteger o acesso aos dados sigilosos da sua empresa.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>O Rufino não solicita nem coleta sua localização. Esta declaração é exigida por uma biblioteca de reconhecimento de texto (OCR) usada na digitalização de documentos.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
O binário MLKitTextRecognitionCommon (google_mlkit_text_recognition) referencia APIs de CoreLocation, o que dispara o aviso ITMS-90683 na App Store mesmo sem o app usar localização. A chave NSLocationWhenInUseUsageDescription declara isso explicitamente.