### PR TITLE
fix(people-management): inclui funcionarios pendentes no filtro do da…

### DIFF
--- a/client/rufino_v2/CLAUDE.md
+++ b/client/rufino_v2/CLAUDE.md
@@ -776,6 +776,7 @@ The app distinguishes "session died" (401) from "no permission" (403) end to end
 - **State preservation:** `DocumentDashboardPage` owns the ViewModel + `ScrollController` lifecycles (same pattern as `EmployeeListPage`) — never create them inside the route builder, or filters/bucket/page/scroll are wiped on every push/pop.
 - **Row navigation** uses `context.push('/employee/:id?tab=documents')`; the `/employee/:id` route maps `?tab=` (`documents` | `contracts`) to `EmployeeProfileScreen.initialTab`, so the profile lands on the Documentos tab and pop returns to the intact dashboard.
 - ViewModel invariant: bucket switch and pagination reload **only the list** (`isLoadingUnits`); filter/horizon changes reload **summary + list together** so the KPI cards never disagree with the rows. Default employee filter is Ativos (status 2).
+- **O filtro "Funcionários" lista os cinco status, id 1 (Pendentes) incluído.** Funcionário ainda em admissão já acumula pendência de documento — os `RequireDocuments` do servidor escutam eventos com `Status.Pending` —, então esconder o status 1 tirava da triagem justamente o recém-contratado. A opção nasceu faltando na lista hardcoded (`_employeeStatusOptions`), não por decisão: nada no servidor nem no ViewModel restringe o valor. Cuidado ao mexer: o label "Pendentes" colide com o do card de KPI (documentos pendentes), e é por isso que os itens do dropdown têm key própria (`employee-status-option-<id>`) — teste que busque por texto pega o card errado.
 
 ## Outdated Document Snapshot (aviso ao gerar)
 

--- a/client/rufino_v2/lib/ui/features/document_dashboard/widgets/document_dashboard_screen.dart
+++ b/client/rufino_v2/lib/ui/features/document_dashboard/widgets/document_dashboard_screen.dart
@@ -96,6 +96,7 @@ class _DocumentDashboardScreenState extends State<DocumentDashboardScreen> {
 
   static const _employeeStatusOptions = [
     (id: null, label: 'Todos'),
+    (id: 1, label: 'Pendentes'),
     (id: 2, label: 'Ativos'),
     (id: 3, label: 'Férias'),
     (id: 4, label: 'Afastados'),
@@ -435,6 +436,8 @@ class _DashboardFilters extends StatelessWidget {
                 items: [
                   for (final option in employeeStatusOptions)
                     DropdownMenuItem<int?>(
+                      key: ValueKey(
+                          'employee-status-option-${option.id ?? 'all'}'),
                       value: option.id,
                       child: Text(option.label),
                     ),

--- a/client/rufino_v2/test/widget/features/document_dashboard/document_dashboard_screen_test.dart
+++ b/client/rufino_v2/test/widget/features/document_dashboard/document_dashboard_screen_test.dart
@@ -173,6 +173,20 @@ void main() {
       expect(find.text('João Souza'), findsOneWidget);
     });
 
+    testWidgets(
+        'filters by employees still in admission when Pendentes is selected',
+        (tester) async {
+      await pumpLoaded(tester);
+
+      await tester.tap(find.byKey(const ValueKey('employee-status-filter')));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.byKey(const ValueKey('employee-status-option-1')).last);
+      await tester.pumpAndSettle();
+
+      expect(dashboardRepository.lastEmployeeStatusId, 1);
+    });
+
     testWidgets('shows the empty state when the bucket has no units',
         (tester) async {
       dashboardRepository.setUnitsPage(


### PR DESCRIPTION
…shboard

A lista hardcoded de status do filtro "Funcionarios" nascia sem o id 1, escondendo da triagem justamente o recem-contratado: funcionario ainda em admissao ja acumula pendencia de documento, porque os RequireDocuments escutam eventos com Status.Pending. Nada no servidor nem no view model restringia o valor.

Os itens do dropdown ganharam key propria porque o label "Pendentes" colide com o do card de KPI (documentos pendentes).