### PR TITLE
feat(rufino): divide uma digitalizacao em documentos de tamanho igual

### DIFF
--- a/client/rufino_v2/CLAUDE.md
+++ b/client/rufino_v2/CLAUDE.md
@@ -793,6 +793,16 @@ The app distinguishes "session died" (401) from "no permission" (403) end to end
 - **"Criar Docs Faltantes" exige grupo ou documento** (`canCreateMissing`) — pendência nasce sempre de um template, e "todos os templates da empresa" não é operação válida. Cada linha do diálogo é o par **funcionário × template** (chave `'employeeId::templateId'`), então `batchCreateDocumentUnits` recebe os pares e agrupa por template.
 - **A lista carrega sem escopo escolhido**: `initState` chama `loadGroupsAndTemplates` e depois `loadPendingUnits`. Testes de widget precisam **rolar** (`drag(-300)`) antes de tocar na barra de ações — a seção de escopo empurrou-a para fora da viewport padrão.
 
+### Dividir a digitalização
+
+O diálogo de fim de digitalização (`_showScanSessionDialog`) tem uma quarta ação — **Dividir** — que corta uma pilha digitalizada em documentos de tamanho igual. O caso de uso é o RH escanear a pilha inteira de uma vez (uma ficha de 2 páginas por funcionário) em vez de digitalizar um funcionário por vez.
+
+- **Dividir só aparece com UM documento de duas ou mais páginas** na sessão (`canSplit`). Com dois ou mais, o usuário já traçou as fronteiras à mão usando "Digitalizar Mais" e cortar por cima delas apagaria essa decisão; com uma página só não há o que cortar. É por isso que Dividir e Digitalizar Mais só aparecem juntos no primeiro documento.
+- **A divisão precisa dar número inteiro.** Sobra de página significa que a pilha não era o que o usuário pensava, e adivinhar onde as páginas ímpares entram anexaria página ao funcionário errado. `validatePagesPerDocument` (`core/utils/page_splitter.dart`) recusa vazio, não-inteiro, `< 1`, maior que o total e resto — e é a mesma função que alimenta a prévia ao vivo ("5 documentos de 2 páginas") no `TextFormField`.
+- **`_resolveScanSession` resolve a divisão num laço próprio**, não no laço de `_scanDocument`: lá `continue` **reabre o scanner**, então cancelar a divisão dispararia uma nova digitalização em vez de voltar à pergunta. Cancelar desfaz só o corte; Descartar (no diálogo pós-divisão) joga a sessão inteira fora, mesmo sentido do Descartar que já existia.
+- **O ViewModel não é tocado.** `processScannedDocuments` já trata cada entrada de `List<List<Uint8List>>` como um documento independente (PDF, OCR, match difuso, reserva da unidade em `assignedUnitIds`), então dividir é só entregar mais entradas. Nome de arquivo (`scan_..._001.pdf`) e o contador do `_BulkProcessingDialog` acertam sozinhos. `splitIntoEqualParts` usa `sublist` — as partes referenciam as mesmas páginas, sem copiar bytes.
+- **A sessão de digitalização é estado local da tela** (`scannedDocuments` em `_scanDocument`), não do VM. A regra mora em `page_splitter.dart`, puro e testado em unit; a tela só chama. Se um dia a sessão subir para o ViewModel, é refactor à parte.
+
 ## Outdated Document Snapshot (aviso ao gerar)
 
 O PDF é montado no backend a partir de um **snapshot** dos dados do funcionário gravado no `Content` da unidade quando a data foi atualizada. O cadastro muda depois, o snapshot não. Antes de gerar, o app pergunta ao backend se ele ainda bate.
@@ -983,6 +993,7 @@ Toda configuração em `core/theme/`: `app_theme.dart` (entry point ThemeData li
 | Scan a document (camera) + OCR | `core/utils/document_scanner_service.dart` | Platform-abstracted (`_mobile` / `_web` / `_stub`). Wraps `cunning_document_scanner`, `camera`, `google_mlkit_text_recognition`. |
 | Build the combined-PDF filename for batch download | `core/utils/combine_file_namer.dart` | Mirrors backend `BatchDownloadQueries.DownloadBatchDocumentUnits` naming. |
 | Fuzzy-match Brazilian names | `core/utils/fuzzy_name_matcher.dart` | Jaro-Winkler + token overlap, accent-insensitive, handles PT connectors. |
+| Cortar uma pilha de páginas digitalizadas em documentos iguais | `core/utils/page_splitter.dart` | `splitIntoEqualParts` (sublists, não copia bytes) + `validatePagesPerDocument` (validator de formulário, recusa resto). Ver "Dividir a digitalização". |
 | Run many async tasks with a concurrency cap | `core/utils/concurrency.dart` | `mapWithConcurrency` — bounded worker pool, preserves input order, `Future.wait` error semantics. Used by batch fan-out (per-template queries, per-page OCR, per-file text extraction). |
 | Generate a request/correlation ID | `data/services/request_id_helper.dart` | UUID v4 for `x-requestid` on mutations. Wraps `uuid`. |
 | Send a multipart upload with progress | `data/services/multipart_upload_helper.dart` | Streams bytes and reports `0.0–1.0` via callback. |

--- a/client/rufino_v2/lib/core/utils/page_splitter.dart
+++ b/client/rufino_v2/lib/core/utils/page_splitter.dart
@@ -1,0 +1,62 @@
+/// Splitting of a scanned page stack into several equally sized documents.
+///
+/// A single scanning pass often captures a pile of documents that all have
+/// the same number of pages — one two-page form per employee, for instance.
+/// Rather than scanning each one separately, the user scans the whole pile
+/// and cuts it here, so the bulk pipeline sees one document per employee.
+///
+/// The split is only defined when every part comes out with the same number
+/// of pages; a remainder means the pile was not what the user thought it
+/// was, and guessing where the odd pages belong would silently attach a page
+/// to the wrong employee.
+library;
+
+/// Splits [items] into consecutive parts of exactly [partSize] elements.
+///
+/// Parts follow the original order: with a part size of 2, the first part
+/// holds elements 1 and 2, the second holds 3 and 4, and so on. Elements are
+/// referenced, never copied, so splitting a stack of page bytes costs no
+/// extra memory.
+///
+/// Requires `items.length` to be a positive multiple of [partSize] — check
+/// the user's input with [validatePagesPerDocument] first.
+List<List<T>> splitIntoEqualParts<T>(List<T> items, int partSize) {
+  assert(partSize >= 1, 'partSize must be at least 1');
+  assert(items.isNotEmpty, 'cannot split an empty list');
+  assert(
+    items.length % partSize == 0,
+    'items.length (${items.length}) must be a multiple of partSize '
+    '($partSize)',
+  );
+
+  return [
+    for (var start = 0; start < items.length; start += partSize)
+      items.sublist(start, start + partSize),
+  ];
+}
+
+/// Form validator for the "páginas por documento" field of a split of
+/// [totalPages] pages.
+///
+/// Returns `null` when [value] cuts the stack into equally sized documents,
+/// or a message in Portuguese explaining why it does not.
+String? validatePagesPerDocument(String? value, {required int totalPages}) {
+  final text = value?.trim() ?? '';
+  if (text.isEmpty) return 'Informe quantas páginas por documento.';
+
+  final pagesPerDocument = int.tryParse(text);
+  if (pagesPerDocument == null) return 'Informe um número inteiro.';
+  if (pagesPerDocument < 1) return 'Mínimo de 1 página por documento.';
+  if (pagesPerDocument > totalPages) {
+    return 'A digitalização tem apenas $totalPages '
+        '${totalPages == 1 ? 'página' : 'páginas'}.';
+  }
+
+  final remainder = totalPages % pagesPerDocument;
+  if (remainder != 0) {
+    return '$totalPages páginas não podem ser divididas a cada '
+        '$pagesPerDocument (sobram $remainder).';
+  }
+
+  return null;
+}

--- a/client/rufino_v2/lib/ui/features/batch_document/widgets/batch_document_screen.dart
+++ b/client/rufino_v2/lib/ui/features/batch_document/widgets/batch_document_screen.dart
@@ -12,6 +12,7 @@ import '../../../../core/theme/app_breakpoints.dart';
 import '../../../../core/theme/app_spacing.dart';
 import '../../../../core/utils/file_saver_stub.dart'
     if (dart.library.io) '../../../../core/utils/file_saver.dart';
+import '../../../../core/utils/page_splitter.dart';
 import '../../../../domain/entities/batch_document_unit.dart';
 import '../../../../domain/entities/employee.dart';
 import '../../../core/widgets/outdated_content_dialog.dart';
@@ -21,9 +22,10 @@ import '../viewmodel/batch_document_viewmodel.dart';
 import 'bulk_upload_verification_dialog.dart';
 import 'confirm_document_dates_dialog.dart';
 import 'document_scan_dialog.dart';
+import 'split_scan_dialog.dart';
 
 /// Possible actions during a multi-document scanning session.
-enum _ScanSessionAction { scanMore, process, discard }
+enum _ScanSessionAction { scanMore, split, process, discard }
 
 /// Main screen for batch document management.
 ///
@@ -234,7 +236,7 @@ class _BatchDocumentScreenState extends State<BatchDocumentScreen> {
       if (pages == null || pages.isEmpty) {
         if (scannedDocuments.isEmpty) return;
         // If documents were already scanned, ask what to do.
-        final action = await _showScanSessionDialog(scannedDocuments.length);
+        final action = await _resolveScanSession(scannedDocuments);
         if (!mounted) return;
         if (action == _ScanSessionAction.process) break;
         if (action == _ScanSessionAction.discard) return;
@@ -245,7 +247,7 @@ class _BatchDocumentScreenState extends State<BatchDocumentScreen> {
       scannedDocuments.add(pages);
 
       // Ask the user if they want to scan another or process all.
-      final action = await _showScanSessionDialog(scannedDocuments.length);
+      final action = await _resolveScanSession(scannedDocuments);
       if (!mounted) return;
       if (action == _ScanSessionAction.process) break;
       if (action == _ScanSessionAction.discard) return;
@@ -276,9 +278,58 @@ class _BatchDocumentScreenState extends State<BatchDocumentScreen> {
     }
   }
 
+  /// Asks what to do next with [scannedDocuments], looping while the user
+  /// experiments with a split.
+  ///
+  /// Splitting is resolved here rather than by the caller because cancelling
+  /// it must return to this question, while the caller's loop would reopen
+  /// the scanner. On a confirmed split, replaces the contents of
+  /// [scannedDocuments] with the resulting documents and returns
+  /// [_ScanSessionAction.process].
+  Future<_ScanSessionAction> _resolveScanSession(
+    List<List<Uint8List>> scannedDocuments,
+  ) async {
+    while (true) {
+      final action = await _showScanSessionDialog(scannedDocuments);
+      if (!mounted) return _ScanSessionAction.discard;
+      if (action != _ScanSessionAction.split) return action;
+
+      final pages = scannedDocuments.single;
+      final pagesPerDocument = await showSplitScanDialog(
+        context,
+        totalPages: pages.length,
+      );
+      if (!mounted) return _ScanSessionAction.discard;
+      // Cancelled the split — ask again, session untouched.
+      if (pagesPerDocument == null) continue;
+
+      final parts = splitIntoEqualParts(pages, pagesPerDocument);
+      final process = await showSplitResultDialog(
+        context,
+        documentCount: parts.length,
+        pagesPerDocument: pagesPerDocument,
+      );
+      if (!mounted) return _ScanSessionAction.discard;
+      if (!process) return _ScanSessionAction.discard;
+
+      scannedDocuments
+        ..clear()
+        ..addAll(parts);
+      return _ScanSessionAction.process;
+    }
+  }
+
   /// Shows a dialog for the user to choose the next action during a
   /// scanning session. Displays the current count of scanned documents.
-  Future<_ScanSessionAction> _showScanSessionDialog(int scannedCount) async {
+  ///
+  /// "Dividir" is offered only for a lone scan of two or more pages: with
+  /// several documents the user already drew the boundaries by hand, and a
+  /// single page has nothing to cut.
+  Future<_ScanSessionAction> _showScanSessionDialog(
+    List<List<Uint8List>> scannedDocuments,
+  ) async {
+    final scannedCount = scannedDocuments.length;
+    final canSplit = scannedCount == 1 && scannedDocuments.single.length > 1;
     final result = await showDialog<_ScanSessionAction>(
       context: context,
       barrierDismissible: false,
@@ -298,8 +349,10 @@ class _BatchDocumentScreenState extends State<BatchDocumentScreen> {
             'Deseja digitalizar mais documentos ou processar os já capturados?',
             style: textTheme.bodyMedium,
           ),
+          actionsOverflowButtonSpacing: AppSpacing.xs,
           actions: [
             TextButton(
+              key: const Key('scan-session-discard'),
               onPressed: () =>
                   Navigator.of(ctx).pop(_ScanSessionAction.discard),
               child: Text(
@@ -307,13 +360,23 @@ class _BatchDocumentScreenState extends State<BatchDocumentScreen> {
                 style: TextStyle(color: colorScheme.error),
               ),
             ),
+            if (canSplit)
+              OutlinedButton.icon(
+                key: const Key('scan-session-split'),
+                onPressed: () =>
+                    Navigator.of(ctx).pop(_ScanSessionAction.split),
+                icon: const Icon(Icons.content_cut, size: 18),
+                label: const Text('Dividir'),
+              ),
             OutlinedButton.icon(
+              key: const Key('scan-session-scan-more'),
               onPressed: () =>
                   Navigator.of(ctx).pop(_ScanSessionAction.scanMore),
               icon: const Icon(Icons.document_scanner_outlined, size: 18),
               label: const Text('Digitalizar Mais'),
             ),
             FilledButton.icon(
+              key: const Key('scan-session-process'),
               onPressed: () =>
                   Navigator.of(ctx).pop(_ScanSessionAction.process),
               icon: const Icon(Icons.check, size: 18),

--- a/client/rufino_v2/lib/ui/features/batch_document/widgets/split_scan_dialog.dart
+++ b/client/rufino_v2/lib/ui/features/batch_document/widgets/split_scan_dialog.dart
@@ -1,0 +1,188 @@
+/// Dialogs that cut a single scanned page stack into equally sized
+/// documents.
+///
+/// Both dialogs deal in page counts only — the bytes never reach them. The
+/// caller owns the pages, asks [showSplitScanDialog] how to cut them, does
+/// the cutting with `splitIntoEqualParts`, and confirms the outcome with
+/// [showSplitResultDialog].
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../core/theme/app_spacing.dart';
+import '../../../../core/utils/page_splitter.dart';
+
+/// Asks how many pages each document should have when splitting a stack of
+/// [totalPages] scanned pages.
+///
+/// Returns the chosen page count, or `null` when the user cancels — which
+/// leaves the scanning session untouched.
+Future<int?> showSplitScanDialog(
+  BuildContext context, {
+  required int totalPages,
+}) {
+  return showDialog<int>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => _SplitScanDialog(totalPages: totalPages),
+  );
+}
+
+/// Confirms the outcome of a split of [documentCount] documents of
+/// [pagesPerDocument] pages each.
+///
+/// Returns `true` when the user chooses to process the documents, and
+/// `false` when they discard the whole scan.
+Future<bool> showSplitResultDialog(
+  BuildContext context, {
+  required int documentCount,
+  required int pagesPerDocument,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) {
+      final colorScheme = Theme.of(ctx).colorScheme;
+      final textTheme = Theme.of(ctx).textTheme;
+      final totalPages = documentCount * pagesPerDocument;
+      return AlertDialog(
+        icon: Icon(Icons.content_cut, color: colorScheme.primary),
+        title: Text(_documentsLabel(documentCount)),
+        content: Text(
+          'A digitalização de ${_pagesLabel(totalPages)} foi dividida em '
+          '${_documentsLabel(documentCount)} de '
+          '${_pagesLabel(pagesPerDocument)}.',
+          style: textTheme.bodyMedium,
+        ),
+        actions: [
+          TextButton(
+            key: const Key('split-result-discard'),
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(
+              'Descartar',
+              style: TextStyle(color: colorScheme.error),
+            ),
+          ),
+          FilledButton.icon(
+            key: const Key('split-result-process'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            icon: const Icon(Icons.check, size: 18),
+            label: const Text('Processar'),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? false;
+}
+
+class _SplitScanDialog extends StatefulWidget {
+  const _SplitScanDialog({required this.totalPages});
+
+  final int totalPages;
+
+  @override
+  State<_SplitScanDialog> createState() => _SplitScanDialogState();
+}
+
+class _SplitScanDialogState extends State<_SplitScanDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// The split the current input describes, or `null` while it is invalid.
+  ///
+  /// Drives the live preview under the field, so the user reads the outcome
+  /// before committing to it.
+  int? get _pagesPerDocument {
+    final error = validatePagesPerDocument(
+      _controller.text,
+      totalPages: widget.totalPages,
+    );
+    if (error != null) return null;
+    return int.parse(_controller.text.trim());
+  }
+
+  void _submit() {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    Navigator.of(context).pop(_pagesPerDocument);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final pagesPerDocument = _pagesPerDocument;
+
+    return AlertDialog(
+      icon: Icon(Icons.content_cut, color: theme.colorScheme.primary),
+      title: const Text('Dividir digitalização'),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${_pagesLabel(widget.totalPages)} '
+              '${widget.totalPages == 1 ? 'capturada' : 'capturadas'}.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.md),
+            TextFormField(
+              key: const Key('split-pages-field'),
+              controller: _controller,
+              autofocus: true,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: const InputDecoration(
+                labelText: 'Páginas por documento',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) => validatePagesPerDocument(
+                value,
+                totalPages: widget.totalPages,
+              ),
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              onChanged: (_) => setState(() {}),
+              onFieldSubmitted: (_) => _submit(),
+            ),
+            if (pagesPerDocument != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                '${_documentsLabel(widget.totalPages ~/ pagesPerDocument)} '
+                'de ${_pagesLabel(pagesPerDocument)}',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          key: const Key('split-scan-cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancelar'),
+        ),
+        FilledButton.icon(
+          key: const Key('split-scan-confirm'),
+          onPressed: _submit,
+          icon: const Icon(Icons.content_cut, size: 18),
+          label: const Text('Dividir'),
+        ),
+      ],
+    );
+  }
+}
+
+String _pagesLabel(int count) => '$count ${count == 1 ? 'página' : 'páginas'}';
+
+String _documentsLabel(int count) =>
+    '$count ${count == 1 ? 'documento' : 'documentos'}';

--- a/client/rufino_v2/test/unit/core/utils/page_splitter_test.dart
+++ b/client/rufino_v2/test/unit/core/utils/page_splitter_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rufino_v2/core/utils/page_splitter.dart';
+
+void main() {
+  group('splitIntoEqualParts', () {
+    test('splits ten pages every two into five parts of two', () {
+      final pages = List.generate(10, (i) => 'p${i + 1}');
+
+      final parts = splitIntoEqualParts(pages, 2);
+
+      expect(parts, hasLength(5));
+      expect(parts.every((part) => part.length == 2), isTrue);
+    });
+
+    test('keeps the original page order across the parts', () {
+      final pages = List.generate(6, (i) => 'p${i + 1}');
+
+      final parts = splitIntoEqualParts(pages, 3);
+
+      expect(parts, [
+        ['p1', 'p2', 'p3'],
+        ['p4', 'p5', 'p6'],
+      ]);
+    });
+
+    test('returns one part per page when the part size is one', () {
+      final pages = List.generate(4, (i) => 'p$i');
+
+      final parts = splitIntoEqualParts(pages, 1);
+
+      expect(parts, hasLength(4));
+      expect(parts.map((part) => part.single), pages);
+    });
+
+    test('returns a single part when the part size equals the total', () {
+      final pages = List.generate(5, (i) => 'p$i');
+
+      final parts = splitIntoEqualParts(pages, 5);
+
+      expect(parts, hasLength(1));
+      expect(parts.single, pages);
+    });
+
+    test('references the original pages instead of copying them', () {
+      final firstPage = ['byte'];
+      final pages = [
+        firstPage,
+        ['other'],
+      ];
+
+      final parts = splitIntoEqualParts(pages, 1);
+
+      expect(identical(parts.first.single, firstPage), isTrue);
+    });
+  });
+
+  group('validatePagesPerDocument', () {
+    test('accepts a value that divides the pages evenly', () {
+      expect(validatePagesPerDocument('2', totalPages: 10), isNull);
+    });
+
+    test('accepts one page per document', () {
+      expect(validatePagesPerDocument('1', totalPages: 7), isNull);
+    });
+
+    test('accepts a value equal to the total page count', () {
+      expect(validatePagesPerDocument('7', totalPages: 7), isNull);
+    });
+
+    test('ignores surrounding whitespace', () {
+      expect(validatePagesPerDocument('  5 ', totalPages: 10), isNull);
+    });
+
+    test('rejects an empty value', () {
+      expect(
+        validatePagesPerDocument('', totalPages: 10),
+        'Informe quantas páginas por documento.',
+      );
+    });
+
+    test('rejects a null value', () {
+      expect(
+        validatePagesPerDocument(null, totalPages: 10),
+        'Informe quantas páginas por documento.',
+      );
+    });
+
+    test('rejects text that is not a whole number', () {
+      expect(
+        validatePagesPerDocument('2,5', totalPages: 10),
+        'Informe um número inteiro.',
+      );
+    });
+
+    test('rejects zero', () {
+      expect(
+        validatePagesPerDocument('0', totalPages: 10),
+        'Mínimo de 1 página por documento.',
+      );
+    });
+
+    test('rejects a negative value', () {
+      expect(
+        validatePagesPerDocument('-2', totalPages: 10),
+        'Mínimo de 1 página por documento.',
+      );
+    });
+
+    test('rejects a value larger than the number of scanned pages', () {
+      expect(
+        validatePagesPerDocument('11', totalPages: 10),
+        'A digitalização tem apenas 10 páginas.',
+      );
+    });
+
+    test('explains how many pages would be left over', () {
+      expect(
+        validatePagesPerDocument('3', totalPages: 10),
+        '10 páginas não podem ser divididas a cada 3 (sobram 1).',
+      );
+    });
+  });
+}

--- a/client/rufino_v2/test/widget/features/batch_document/batch_document_screen_test.dart
+++ b/client/rufino_v2/test/widget/features/batch_document/batch_document_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 import 'package:rufino_v2/core/result.dart';
+import 'package:rufino_v2/core/utils/page_rotation_finder.dart';
 import 'package:rufino_v2/domain/entities/batch_document_unit.dart';
 import 'package:rufino_v2/domain/entities/document_group_with_templates.dart';
 import 'package:rufino_v2/domain/entities/employee.dart';
@@ -629,6 +630,139 @@ void main() {
             any(),
             any(),
           )).called(1);
+    });
+  });
+
+  group('BatchDocumentScreen scanning session', () {
+    late MockDocumentScannerRepository mockScanner;
+
+    /// Rotation stub that never rotates, so the real image decoder and the
+    /// compute isolate stay out of the widget test.
+    Future<RotationCandidate?> noRotation({
+      required Uint8List originalBytes,
+      required String originalText,
+      required Future<String> Function(Uint8List) recognizeText,
+    }) async =>
+        null;
+
+    List<Uint8List> pages(int count) => [
+          for (var i = 0; i < count; i++) Uint8List.fromList([0xFF, 0xD8, i]),
+        ];
+
+    setUp(() {
+      registerFallbackValue(Uint8List(0));
+      registerFallbackValue(<Uint8List>[]);
+
+      mockScanner = MockDocumentScannerRepository();
+      when(() => mockScanner.isPlatformSupported).thenReturn(true);
+      when(() => mockScanner.recognizeText(any())).thenAnswer((_) async => '');
+      when(() => mockScanner.imagesToPdf(any()))
+          .thenAnswer((_) async => Uint8List.fromList([0x25, 0x50, 0x44]));
+
+      viewModel.dispose();
+      viewModel = BatchDocumentViewModel(
+        batchDocumentRepository: mockBatchRepo,
+        documentGroupRepository: mockGroupRepo,
+        employeeRepository: fakeEmployeeRepo,
+        companyId: 'company-1',
+        scannerRepository: mockScanner,
+        pageRotationFinder: noRotation,
+        textExtractor: (_) async => '',
+      );
+    });
+
+    /// Opens the screen, scans one stack of [pageCount] pages and stops at
+    /// the session dialog.
+    Future<void> scanOnce(WidgetTester tester, int pageCount) async {
+      when(() => mockScanner.scanPages())
+          .thenAnswer((_) async => Result.success(pages(pageCount)));
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Digitalizar'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Digitalizar'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('offers splitting a lone scan of several pages',
+        (tester) async {
+      await scanOnce(tester, 4);
+
+      expect(find.text('1 documento digitalizado'), findsOneWidget);
+      expect(find.byKey(const Key('scan-session-split')), findsOneWidget);
+    });
+
+    testWidgets('does not offer splitting a single page', (tester) async {
+      await scanOnce(tester, 1);
+
+      expect(find.byKey(const Key('scan-session-split')), findsNothing);
+      expect(find.byKey(const Key('scan-session-scan-more')), findsOneWidget);
+    });
+
+    testWidgets('does not offer splitting once a second document is scanned',
+        (tester) async {
+      await scanOnce(tester, 4);
+
+      await tester.tap(find.byKey(const Key('scan-session-scan-more')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2 documentos digitalizados'), findsOneWidget);
+      expect(find.byKey(const Key('scan-session-split')), findsNothing);
+    });
+
+    testWidgets('processes one document per part after a split',
+        (tester) async {
+      await scanOnce(tester, 4);
+
+      await tester.tap(find.byKey(const Key('scan-session-split')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('4 páginas capturadas.'), findsOneWidget);
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '2');
+      await tester.tap(find.byKey(const Key('split-scan-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2 documentos'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('split-result-process')));
+      await tester.pumpAndSettle();
+
+      // One PDF per part: the four scanned pages became two documents.
+      verify(() => mockScanner.imagesToPdf(any())).called(2);
+    });
+
+    testWidgets('returns to the session dialog when the split is cancelled',
+        (tester) async {
+      await scanOnce(tester, 4);
+
+      await tester.tap(find.byKey(const Key('scan-session-split')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('split-scan-cancel')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 documento digitalizado'), findsOneWidget);
+      expect(find.byKey(const Key('scan-session-split')), findsOneWidget);
+      verifyNever(() => mockScanner.imagesToPdf(any()));
+    });
+
+    testWidgets('processes nothing when the split result is discarded',
+        (tester) async {
+      await scanOnce(tester, 4);
+
+      await tester.tap(find.byKey(const Key('scan-session-split')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '2');
+      await tester.tap(find.byKey(const Key('split-scan-confirm')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('split-result-discard')));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => mockScanner.imagesToPdf(any()));
+      expect(find.text('2 documentos'), findsNothing);
     });
   });
 }

--- a/client/rufino_v2/test/widget/features/batch_document/split_scan_dialog_test.dart
+++ b/client/rufino_v2/test/widget/features/batch_document/split_scan_dialog_test.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rufino_v2/ui/features/batch_document/widgets/split_scan_dialog.dart';
+
+void main() {
+  /// Pumps a host screen whose button opens [open] and stores its result.
+  Future<void> pumpHost<T>(
+    WidgetTester tester,
+    Future<T> Function(BuildContext context) open,
+    void Function(T result) onResult,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async => onResult(await open(context)),
+                child: const Text('Abrir'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Abrir'));
+    await tester.pumpAndSettle();
+  }
+
+  group('showSplitScanDialog', () {
+    testWidgets('states how many pages were captured', (tester) async {
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (_) {},
+      );
+
+      expect(find.text('Dividir digitalização'), findsOneWidget);
+      expect(find.text('10 páginas capturadas.'), findsOneWidget);
+    });
+
+    testWidgets('previews the resulting documents for a valid value',
+        (tester) async {
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (_) {},
+      );
+
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '2');
+      await tester.pump();
+
+      expect(find.text('5 documentos de 2 páginas'), findsOneWidget);
+    });
+
+    testWidgets('uses the singular form when the split yields one document',
+        (tester) async {
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 4),
+        (_) {},
+      );
+
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '4');
+      await tester.pump();
+
+      expect(find.text('1 documento de 4 páginas'), findsOneWidget);
+    });
+
+    testWidgets('shows an error and keeps the dialog open when pages are '
+        'left over', (tester) async {
+      int? result;
+      var completed = false;
+
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (value) {
+          result = value;
+          completed = true;
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '3');
+      await tester.tap(find.byKey(const Key('split-scan-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('10 páginas não podem ser divididas a cada 3 (sobram 1).'),
+        findsOneWidget,
+      );
+      expect(find.text('Dividir digitalização'), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('does not close when confirming without a value',
+        (tester) async {
+      var completed = false;
+
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (_) => completed = true,
+      );
+
+      await tester.tap(find.byKey(const Key('split-scan-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Informe quantas páginas por documento.'),
+          findsOneWidget);
+      expect(completed, isFalse);
+    });
+
+    testWidgets('returns the chosen page count when confirmed',
+        (tester) async {
+      int? result;
+
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (value) => result = value,
+      );
+
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '2');
+      await tester.tap(find.byKey(const Key('split-scan-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(result, 2);
+    });
+
+    testWidgets('returns null when cancelled', (tester) async {
+      int? result;
+      var completed = false;
+
+      await pumpHost<int?>(
+        tester,
+        (context) => showSplitScanDialog(context, totalPages: 10),
+        (value) {
+          result = value;
+          completed = true;
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('split-pages-field')), '2');
+      await tester.tap(find.byKey(const Key('split-scan-cancel')));
+      await tester.pumpAndSettle();
+
+      expect(completed, isTrue);
+      expect(result, isNull);
+    });
+  });
+
+  group('showSplitResultDialog', () {
+    testWidgets('describes the split it is confirming', (tester) async {
+      await pumpHost<bool>(
+        tester,
+        (context) => showSplitResultDialog(
+          context,
+          documentCount: 5,
+          pagesPerDocument: 2,
+        ),
+        (_) {},
+      );
+
+      expect(find.text('5 documentos'), findsOneWidget);
+      expect(
+        find.text(
+          'A digitalização de 10 páginas foi dividida em 5 documentos '
+          'de 2 páginas.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('returns true when the user processes the documents',
+        (tester) async {
+      bool? result;
+
+      await pumpHost<bool>(
+        tester,
+        (context) => showSplitResultDialog(
+          context,
+          documentCount: 5,
+          pagesPerDocument: 2,
+        ),
+        (value) => result = value,
+      );
+
+      await tester.tap(find.byKey(const Key('split-result-process')));
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('returns false when the user discards the scan',
+        (tester) async {
+      bool? result;
+
+      await pumpHost<bool>(
+        tester,
+        (context) => showSplitResultDialog(
+          context,
+          documentCount: 5,
+          pagesPerDocument: 2,
+        ),
+        (value) => result = value,
+      );
+
+      await tester.tap(find.byKey(const Key('split-result-discard')));
+      await tester.pumpAndSettle();
+
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
O RH escaneia a pilha inteira de uma vez - uma ficha de 2 paginas por funcionario - em vez de digitalizar um funcionario por vez, e corta no fim. "Dividir" entra como quarta acao do dialogo de fim de digitalizacao, ao lado de Descartar, Digitalizar Mais e Processar: o usuario informa a cada quantas paginas cortar, e cada parte vira um documento do pipeline de OCR e match difuso ja existente.

- Dividir so aparece com UM documento de duas ou mais paginas na sessao. Com dois ou mais o usuario ja tracou as fronteiras a mao usando Digitalizar Mais, e cortar por cima apagaria essa decisao; com uma pagina nao ha o que cortar. E por isso que Dividir e Digitalizar Mais so aparecem juntos no primeiro documento.
- A divisao precisa dar numero inteiro. Sobra de pagina significa que a pilha nao era o que o usuario pensava, e adivinhar onde as paginas impares entram anexaria pagina ao funcionario errado. validatePagesPerDocument recusa vazio, nao-inteiro, < 1, maior que o total e resto - e e a mesma funcao que alimenta a previa ao vivo ("5 documentos de 2 paginas") no campo.
- _resolveScanSession resolve a divisao num laco proprio, nao no laco de _scanDocument: la o continue REABRE o scanner, entao cancelar a divisao dispararia uma nova digitalizacao em vez de voltar a pergunta. Cancelar desfaz so o corte; Descartar joga a sessao inteira fora, mesmo sentido do Descartar que ja existia.
- O ViewModel nao foi tocado. processScannedDocuments ja trata cada entrada de List<List<Uint8List>> como documento independente, entao dividir e so entregar mais entradas: nome de arquivo e contador de progresso acertam sozinhos. splitIntoEqualParts usa sublist, entao as partes referenciam as mesmas paginas e nenhum byte e copiado.
- A sessao de digitalizacao continua sendo estado local da tela. A regra mora em core/utils/page_splitter.dart, pura e testada em unit; a tela so chama. Subir a sessao para o ViewModel e refactor a parte.
- Testes: os botoes do dialogo de sessao ganharam Key e entra a cobertura que nao existia - nenhum teste tocava o dialogo de fim de digitalizacao.